### PR TITLE
[feat] 헤더 제작 및 ★★(중요)headerState 변경 요청★★

### DIFF
--- a/public/assets/images/header/header-star.svg
+++ b/public/assets/images/header/header-star.svg
@@ -1,0 +1,15 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="recommend/ic/star">
+<g id="Star 15" filter="url(#filter0_b_798_8773)">
+<path d="M9.44251 2.07054C9.59589 1.50088 10.4041 1.50088 10.5575 2.07054L12.0349 7.55771C12.0884 7.7564 12.2436 7.9116 12.4423 7.9651L17.9295 9.44251C18.4991 9.59589 18.4991 10.4041 17.9295 10.5575L12.4423 12.0349C12.2436 12.0884 12.0884 12.2436 12.0349 12.4423L10.5575 17.9295C10.4041 18.4991 9.59589 18.4991 9.44251 17.9295L7.9651 12.4423C7.9116 12.2436 7.7564 12.0884 7.55771 12.0349L2.07054 10.5575C1.50088 10.4041 1.50088 9.59589 2.07054 9.44251L7.55771 7.9651C7.7564 7.9116 7.9116 7.7564 7.9651 7.55771L9.44251 2.07054Z" fill="#5C5FFA"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_b_798_8773" x="-1.84899" y="-1.84703" width="23.698" height="23.6941" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImageFix" stdDeviation="1.74481"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_798_8773"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_798_8773" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import KakaoLogin from '../login/KakaoLogin';
+import KakaoLogin, { kakaoAuthorize } from '../login/KakaoLogin';
 import { useRecoilValue } from 'recoil';
 import { kakaoNameState, loginState } from '../../recoil/atom';
 
 import logoSrc from '/assets/images/header/wanteam-logo.svg';
+import starSrc from '/assets/images/header/header-star.svg';
 
 const Header = () => {
   const kakaoName = useRecoilValue(kakaoNameState);
@@ -14,14 +15,22 @@ const Header = () => {
     <HeaderLayout>
       <Logo src={logoSrc} onClick={() => navigate('/')} />
       <HeaderContainer>
-        <HeaderItem>공모전 리스트</HeaderItem>
-        <HeaderItem>내팀</HeaderItem>
+        <HeaderItem>
+          <HeaderStar src={starSrc} />
+          공모전 리스트
+        </HeaderItem>
+        <HeaderItem>
+          <HeaderStar src={starSrc} />내 팀
+        </HeaderItem>
         {isLogin ? (
           <>
-            <HeaderItem>{kakaoName}님 </HeaderItem>
+            <HeaderItem>
+              <HeaderStar src={starSrc} />
+              {kakaoName}님{' '}
+            </HeaderItem>
           </>
         ) : (
-          <KakaoLogin />
+          <HeaderItem onClick={kakaoAuthorize}>로그인/회원가입</HeaderItem>
         )}
       </HeaderContainer>
       {/* {isLogin ? <KakaoLogout /> : <KakaoLogin />} */}
@@ -35,7 +44,10 @@ const HeaderLayout = styled.header`
   max-width: 122.4rem;
   height: 10rem;
   margin: auto;
-  background-color: ${(props) => props.theme.colors.gray10};
+  background-color: rgba(255, 255, 255, 0.8);
+  border-bottom: 1px solid ${(props) => props.theme.colors.gray10};
+
+  backdrop-filter: blur(8px);
 
   display: flex;
   justify-content: space-between;
@@ -52,8 +64,30 @@ const HeaderContainer = styled.div`
   display: flex;
   justify-content: space-around;
   align-items: center;
-  gap: 3rem;
+  /* gap: 3rem; */
 `;
 const HeaderItem = styled.div`
-  font-size: 2rem;
+  ${(props) => props.theme.fonts.bodyM};
+  color: ${(props) => props.theme.colors.gray80};
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: relative;
+
+  /* min-width: 13.1rem; */
+
+  text-align: center;
+
+  padding: 1.2rem 0.8rem;
+  margin: 0 2rem;
+  /* border: 1px solid red; */
+`;
+const HeaderStar = styled.img`
+  width: 2rem;
+  height: 2rem;
+
+  position: absolute;
+  left: -1.8rem;
 `;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,36 +1,48 @@
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import KakaoLogin, { kakaoAuthorize } from '../login/KakaoLogin';
+import { kakaoAuthorize } from '../login/KakaoLogin';
 import { useRecoilValue } from 'recoil';
-import { kakaoNameState, loginState } from '../../recoil/atom';
+import {
+  headerSelectedState,
+  kakaoNameState,
+  loginState,
+} from '../../recoil/atom';
 
 import logoSrc from '/assets/images/header/wanteam-logo.svg';
 import starSrc from '/assets/images/header/header-star.svg';
+import { Headers } from '../../constants/Header';
 
 const Header = () => {
   const kakaoName = useRecoilValue(kakaoNameState);
   const isLogin = useRecoilValue(loginState);
+  const headerSelectedIndex = useRecoilValue(headerSelectedState);
   const navigate = useNavigate();
   return (
     <HeaderLayout>
       <Logo src={logoSrc} onClick={() => navigate('/')} />
       <HeaderContainer>
-        <HeaderItem>
+        <HeaderItem $isSelected={headerSelectedIndex === Headers.list}>
           <HeaderStar src={starSrc} />
           공모전 리스트
         </HeaderItem>
-        <HeaderItem>
+        <HeaderItem $isSelected={headerSelectedIndex === Headers.myTeam}>
           <HeaderStar src={starSrc} />내 팀
         </HeaderItem>
         {isLogin ? (
           <>
-            <HeaderItem>
+            <HeaderItem $isSelected={headerSelectedIndex === Headers.myPage}>
               <HeaderStar src={starSrc} />
               {kakaoName}님{' '}
             </HeaderItem>
           </>
         ) : (
-          <HeaderItem onClick={kakaoAuthorize}>로그인/회원가입</HeaderItem>
+          <HeaderItem
+            $isSelected={headerSelectedIndex === Headers.login}
+            onClick={kakaoAuthorize}
+          >
+            <HeaderStar src={starSrc} />
+            로그인/회원가입
+          </HeaderItem>
         )}
       </HeaderContainer>
       {/* {isLogin ? <KakaoLogout /> : <KakaoLogin />} */}
@@ -66,9 +78,16 @@ const HeaderContainer = styled.div`
   align-items: center;
   /* gap: 3rem; */
 `;
-const HeaderItem = styled.div`
-  ${(props) => props.theme.fonts.bodyM};
+const HeaderItem = styled.button<{ $isSelected: boolean }>`
   color: ${(props) => props.theme.colors.gray80};
+
+  ${(props) =>
+    props.$isSelected ? props.theme.fonts.subtitleM : props.theme.fonts.bodyM};
+
+  color: ${(props) =>
+    props.$isSelected
+      ? props.theme.colors.primary60
+      : props.theme.colors.gray80};
 
   display: flex;
   justify-content: center;
@@ -83,6 +102,9 @@ const HeaderItem = styled.div`
   padding: 1.2rem 0.8rem;
   margin: 0 2rem;
   /* border: 1px solid red; */
+  > img {
+    display: ${(props) => (props.$isSelected ? 'default' : 'none')};
+  }
 `;
 const HeaderStar = styled.img`
   width: 2rem;

--- a/src/components/login/KakaoLogin.tsx
+++ b/src/components/login/KakaoLogin.tsx
@@ -1,19 +1,28 @@
-import kakaoLoginImageSrc from '/assets/images/header/kakaoLogin.png';
+// import kakaoLoginImageSrc from '/assets/images/header/kakaoLogin.png';
 
 export const kakao = (window as any).Kakao;
+
+
+export const kakaoAuthorize = () => {
+  const redirectUri = 'http://localhost:5173/login/oauth';
+  kakao.Auth.authorize({
+    redirectUri: `${redirectUri}`,
+    scope: 'profile_nickname,profile_image,account_email,account_email',
+  });
+};
 
 const KakaoLogin = () => {
   const redirectUri = 'http://localhost:5173/login/oauth';
   return (
-    <img
-      src={kakaoLoginImageSrc}
+    <div
+      // src={kakaoLoginImageSrc}
       onClick={() =>
         kakao.Auth.authorize({
           redirectUri: `${redirectUri}`,
           scope: 'profile_nickname,profile_image,account_email,account_email',
         })
       }
-    ></img>
+    >마이페이지</div>
   );
 };
 export default KakaoLogin;

--- a/src/constants/Header.ts
+++ b/src/constants/Header.ts
@@ -1,0 +1,7 @@
+export enum Headers {
+  none = 'none',
+  list = 'list',
+  myTeam = 'myTeam',
+  login = 'login',
+  myPage = 'myPage',
+}

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import postJoin from '../../apis/join/postJoin';
 import { useLocation } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { headerSelectedState } from '../../recoil/atom';
+import { Headers } from '../../constants/Header';
 const REGIONS = [
   '무관',
   '서울',
@@ -64,8 +67,11 @@ const Join = () => {
 
       return newObj;
     });
-    
   };
+
+  const setHeaderSelected = useSetRecoilState(headerSelectedState);
+  useEffect(() => setHeaderSelected(Headers.none));
+
   return (
     <JoinLayout>
       <FormContainer action="#" onSubmit={handleSubmit}>

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -6,10 +6,18 @@ import ProfileKeyword from '../../components/profile/ProfileKeyword';
 import ProfileRecommendation from '../../components/profile/ProfileRecommendation';
 import ProfilePersonality from '../../components/profile/ProfilePersonality';
 import { profileDatas, reviewDatas } from '../../constants/Profile';
+import { useSetRecoilState } from 'recoil';
+import { headerSelectedState } from '../../recoil/atom';
+import { useEffect } from 'react';
+import { Headers } from '../../constants/Header';
 
 const Profile = () => {
   const { userId } = useParams();
-  userId;
+  const setHeaderSelected = useSetRecoilState(headerSelectedState);
+  userId; //이거는 일단 무시해주세요
+
+  useEffect(() => setHeaderSelected(Headers.list));
+
   return (
     <ProfileLayout>
       <ProfileInfo profileData={profileDatas} />

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -6,7 +6,10 @@ export type HeaderSelectedType =
   | 'myTeam'
   | 'login'
   | 'myPage'; //추가 가능
-
+export const headerSelectedState = atom<HeaderSelectedType>({
+  key: 'headerSelectedState',
+  default: Headers.none,
+});
 export const kakaoNameState = atom({
   key: 'kakaoNameState',
   default: 'noname',
@@ -19,7 +22,4 @@ export const loginState = atom<boolean>({
   key: 'loginState',
   default: false,
 });
-export const headerSelectedState = atom<HeaderSelectedType>({
-  key: 'headerSelectedState',
-  default: Headers.myPage,
-});
+

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,10 +1,11 @@
 import { atom } from 'recoil';
+import { Headers } from '../constants/Header';
 export type HeaderSelectedType =
   | 'none'
   | 'list'
   | 'myTeam'
   | 'login'
-  | 'mypage'; //추가 가능
+  | 'myPage'; //추가 가능
 
 export const kakaoNameState = atom({
   key: 'kakaoNameState',
@@ -20,5 +21,5 @@ export const loginState = atom<boolean>({
 });
 export const headerSelectedState = atom<HeaderSelectedType>({
   key: 'headerSelectedState',
-  default: 'none',
+  default: Headers.myPage,
 });

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,9 +1,10 @@
 import { atom } from 'recoil';
-export type HeaderColorType = 'transparent' | 'white'; //추가 가능
-export const currHeaderAtom = atom<HeaderColorType>({
-  key: 'currHeader',
-  default: 'white',
-});
+export type HeaderSelectedType =
+  | 'none'
+  | 'list'
+  | 'myTeam'
+  | 'login'
+  | 'mypage'; //추가 가능
 
 export const kakaoNameState = atom({
   key: 'kakaoNameState',
@@ -16,4 +17,8 @@ export const kakaoAccessTokenState = atom({
 export const loginState = atom<boolean>({
   key: 'loginState',
   default: false,
+});
+export const headerSelectedState = atom<HeaderSelectedType>({
+  key: 'headerSelectedState',
+  default: 'none',
 });


### PR DESCRIPTION
### 관련 이슈

- close #6 

### PR Checklist for Reviewer

- [x] 헤더 제작 완료

★★**중요 전달 사항**★★
현재 헤더의 상태를 알려주는 별과 볼드체는 `headerSelectedState`라는 Recoil 변수로 관리되며, 전역 state입니다.

![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/77064618/14b97452-498b-41b4-975d-855545df08bb)
![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/77064618/d20b8224-b7aa-4beb-8629-f622a60c9981)

<br><br><br><br>
`headerSelectedState`의 값으로 사용될 수 있는 것들은 총 5개이며, `constants/Header.ts` 에 `enum`으로 정의했습니다. 
`Headers.list` 처럼 사용하여 오탈자를 방지할 수 있으며, 각 값은 다음을 의미합니다.
- `none' : seletedHeader가 없음
- 'list` : seletedHeader가 **공모전 리스트**
- 'myTeam` : seletedHeader가 **내 팀**
- 'login` : seletedHeader가 **로그인/회원가입**
- 'myPage` : seletedHeader가 **마이페이지**(현재는 디버깅을 위해 xxx님으로 설정)
![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/77064618/9c61a9d6-8f13-424c-ba2d-9635a324e405)


<br><br><br><br>
각 페이지마다 `headerSelectedState`가 다르기 때문에, 페이지를 만들 때 최상위 파일(pages폴더 내부에 존재하는 파일)에 `headerSeletedState`를 적절한 값으로 직접 설정해주어야 합니다.
피그마 스토리보드의 x.x.x에서 첫번째 x값에 맞춰주면 됩니다.

또는 필요하다고 생각되는 컴포넌트에 맞게 설정해 주면 됩니다.

#### `headerSelectedState`설정 방법

`pages/profile/Profile.tsx`
![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/77064618/0f486f00-6fab-4c32-8c6c-015c579a692b)
`http://localhost:5173/profile/123`로 접속하면 **공모전 리스트**에 별이 생깁니다.


### 테스트 결과
페이지 흐름이 많이 나오지 않아서, 전체적으로 적용하면서 해주세요
