### PR TITLE
[feat] 헤더 변경내용 적용, 로그인 커스텀 훅 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.0.8"
   },
   "devDependencies": {

--- a/public/assets/images/header/dropdown-button.svg
+++ b/public/assets/images/header/dropdown-button.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector 498" d="M1 1.5L6 6.5L11 1.5" stroke="#404079" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/apis/join/postJoin.ts
+++ b/src/apis/join/postJoin.ts
@@ -1,13 +1,11 @@
 import { RequestJoin } from '../../interface/Join';
 import Axios from '../axios';
 
-const postJoin = (kakaoAccessToken: string, joinData: RequestJoin) =>
+const postJoin = (requestData : RequestJoin  ) =>
   Axios.post(
     '/api/auth/register',
     {
-      kakaoAccessToken: kakaoAccessToken,
-      username: joinData.name,
-      age: 987654,
+      ...requestData
     },
     {
       headers: {

--- a/src/apis/login/postKakaoAccessTokenFromCode.ts
+++ b/src/apis/login/postKakaoAccessTokenFromCode.ts
@@ -5,7 +5,7 @@ const client_id = import.meta.env.VITE_KAKAO_CLIENT_ID;
 const redirect_uri = 'http://localhost:5173/login/oauth';
 const postUrl = 'https://kauth.kakao.com/oauth/token';
 
-const postKakaoAccessToken = (accessCode: string) =>
+const postKakaoAccessTokenFromCode = (accessCode: string) =>
   axios.post(
     postUrl,
     {
@@ -21,4 +21,4 @@ const postKakaoAccessToken = (accessCode: string) =>
     },
   );
 
-export default postKakaoAccessToken;
+export default postKakaoAccessTokenFromCode;

--- a/src/apis/login/postLoginWithKakaoToken.ts
+++ b/src/apis/login/postLoginWithKakaoToken.ts
@@ -1,6 +1,6 @@
 import Axios from '../axios';
 
-const postKakaoToken = (kakaoAccessToken: string) =>
+const postLoginWithKakaoToken = (kakaoAccessToken: string) =>
   Axios.post(
     '/api/auth/login',
     {
@@ -14,4 +14,4 @@ const postKakaoToken = (kakaoAccessToken: string) =>
     },
   );
 
-export default postKakaoToken;
+export default postLoginWithKakaoToken;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { headerSelectedState, loginState } from '../../recoil/atom';
 
@@ -14,16 +14,17 @@ const Header = () => {
   const headerSelectedIndex = useRecoilValue(headerSelectedState);
   const navigate = useNavigate();
   useEffect(() => {
-    if (localStorage.getItem('kawq;ejqwken')) setIsLogin(true);
-    // if (localStorage.getItem('kakaoAccessToken')) setIsLogin(true);
-  }, []);
+    if (localStorage.getItem('kakaoAccessToken')) setIsLogin(true);
+  }, [isLogin]);
   return (
     <>
       <Spacer />
       <HeaderLayout>
         <HeaderContentContainer>
           <HeaderContainer>
-            <Logo src={logoSrc} onClick={() => navigate('/')} />
+            <Link to={'/'}>
+              <Logo src={logoSrc} />
+            </Link>
             <HeaderItem
               $isSelected={headerSelectedIndex === Headers.list}
               onClick={() => navigate('/list')}
@@ -39,14 +40,7 @@ const Header = () => {
             </HeaderItem>
           </HeaderContainer>{' '}
           {isLogin ? (
-            <>
-              <HeaderItem
-                $isSelected={headerSelectedIndex === Headers.myProfile}
-              >
-                <LoginProfile />
-                <HeaderStar src={starSrc} />님{' '}
-              </HeaderItem>
-            </>
+            <LoginProfile />
           ) : (
             <HeaderItem
               $isSelected={headerSelectedIndex === Headers.login}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,19 +1,15 @@
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import {
-  headerSelectedState,
-  kakaoNameState,
-  loginState,
-} from '../../recoil/atom';
+import { headerSelectedState, loginState } from '../../recoil/atom';
 
 import logoSrc from '/assets/images/header/wanteam-logo.svg';
 import starSrc from '/assets/images/common/star.svg';
 import { Headers } from '../../constants/Header';
 import { useEffect } from 'react';
+import LoginProfile from './LoginProfile';
 
 const Header = () => {
-  const kakaoName = useRecoilValue(kakaoNameState);
   const [isLogin, setIsLogin] = useRecoilState(loginState);
   const headerSelectedIndex = useRecoilValue(headerSelectedState);
   const navigate = useNavigate();
@@ -47,8 +43,8 @@ const Header = () => {
               <HeaderItem
                 $isSelected={headerSelectedIndex === Headers.myProfile}
               >
-                <HeaderStar src={starSrc} />
-                {kakaoName}님{' '}
+                <LoginProfile />
+                <HeaderStar src={starSrc} />님{' '}
               </HeaderItem>
             </>
           ) : (

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,21 +1,20 @@
 import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { headerSelectedState, loginState } from '../../recoil/atom';
+import { useRecoilValue } from 'recoil';
+import { headerSelectedState, loginInfoState } from '../../recoil/atom';
 
 import logoSrc from '/assets/images/header/wanteam-logo.svg';
 import starSrc from '/assets/images/common/star.svg';
 import { Headers } from '../../constants/Header';
-import { useEffect } from 'react';
 import LoginProfile from './LoginProfile';
 
 const Header = () => {
-  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const loginInfo = useRecoilValue(loginInfoState);
   const headerSelectedIndex = useRecoilValue(headerSelectedState);
   const navigate = useNavigate();
-  useEffect(() => {
-    if (localStorage.getItem('kakaoAccessToken')) setIsLogin(true);
-  }, [isLogin]);
+  // useEffect(() => {
+  //   if (localStorage.getItem('kakaoAccessToken')) setIsLogin(true);
+  // }, [isLogin]);
   return (
     <>
       <Spacer />
@@ -39,7 +38,7 @@ const Header = () => {
               <HeaderStar src={starSrc} />내 프로필
             </HeaderItem>
           </HeaderContainer>{' '}
-          {isLogin ? (
+          {loginInfo.isLogin ? (
             <LoginProfile />
           ) : (
             <HeaderItem

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -26,38 +26,40 @@ const Header = () => {
       <Spacer />
       <HeaderLayout>
         <HeaderContentContainer>
-          <Logo src={logoSrc} onClick={() => navigate('/')} />
           <HeaderContainer>
+            <Logo src={logoSrc} onClick={() => navigate('/')} />
             <HeaderItem
               $isSelected={headerSelectedIndex === Headers.list}
               onClick={() => navigate('/list')}
             >
-    
               <HeaderStar src={starSrc} />
               공모전 리스트
             </HeaderItem>
             <HeaderItem $isSelected={headerSelectedIndex === Headers.myTeam}>
               <HeaderStar src={starSrc} />내 팀
             </HeaderItem>
-            {isLogin ? (
-              <>
-                <HeaderItem
-                  $isSelected={headerSelectedIndex === Headers.myPage}
-                >
-                  <HeaderStar src={starSrc} />
-                  {kakaoName}님{' '}
-                </HeaderItem>
-              </>
-            ) : (
+            <HeaderItem $isSelected={headerSelectedIndex === Headers.myProfile}>
+              <HeaderStar src={starSrc} />내 프로필
+            </HeaderItem>
+          </HeaderContainer>{' '}
+          {isLogin ? (
+            <>
               <HeaderItem
-                $isSelected={headerSelectedIndex === Headers.login}
-                onClick={() => navigate('/login')}
+                $isSelected={headerSelectedIndex === Headers.myProfile}
               >
                 <HeaderStar src={starSrc} />
-                로그인/회원가입
+                {kakaoName}님{' '}
               </HeaderItem>
-            )}
-          </HeaderContainer>
+            </>
+          ) : (
+            <HeaderItem
+              $isSelected={headerSelectedIndex === Headers.login}
+              onClick={() => navigate('/login')}
+            >
+              <HeaderStar src={starSrc} />
+              로그인/회원가입
+            </HeaderItem>
+          )}
         </HeaderContentContainer>
       </HeaderLayout>
     </>
@@ -100,12 +102,14 @@ const Logo = styled.img`
   height: 4.2rem;
   /* background-color: red; */
   cursor: pointer;
+
+  margin-right: 3rem;
 `;
 const HeaderContainer = styled.div`
   display: flex;
   justify-content: space-around;
   align-items: center;
-  /* gap: 3rem; */
+  gap: 5rem;
 `;
 const HeaderItem = styled.button<{ $isSelected: boolean }>`
   color: ${(props) => props.theme.colors.gray80};
@@ -129,12 +133,12 @@ const HeaderItem = styled.button<{ $isSelected: boolean }>`
   text-align: center;
 
   padding: 1.2rem 0.8rem;
-  margin: 0 2rem;
   /* border: 1px solid red; */
   > img {
     display: ${(props) => (props.$isSelected ? 'default' : 'none')};
   }
 `;
+
 const HeaderStar = styled.img`
   width: 2rem;
   height: 2rem;

--- a/src/components/header/LoginProfile.tsx
+++ b/src/components/header/LoginProfile.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const LoginProfile = () => {
+  return (
+    <ProfileContainer>
+      <ProfileImg />
+      <ProfileName></ProfileName>
+    </ProfileContainer>
+  );
+};
+const ProfileContainer = styled.div``;
+const ProfileImg = styled.div``;
+const ProfileName = styled.div``;
+
+export default LoginProfile;

--- a/src/components/header/LoginProfile.tsx
+++ b/src/components/header/LoginProfile.tsx
@@ -1,20 +1,20 @@
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import { kakaoInfoState } from '../../recoil/atom';
+import { loginInfoState } from '../../recoil/atom';
 import { useState } from 'react';
 
 import dropSrc from '/assets/images/header/dropdown-button.svg';
 
 const LoginProfile = () => {
-  const kakaoInfo = useRecoilValue(kakaoInfoState);
+  const loginState = useRecoilValue(loginInfoState);
   const [isDrop, setIsDrop] = useState(false);
   const handleClick = () => {
     setIsDrop((curr) => !curr);
   };
   return (
     <ProfileContainer onClick={handleClick}>
-      <ProfileImg src={kakaoInfo.image} />
-      <ProfileName>{kakaoInfo.name}</ProfileName>
+      <ProfileImg src={loginState.data?.profileImage} />
+      <ProfileName>{loginState.data?.name}</ProfileName>
       {/* 실제이름으로 변경하기 */}
       <ProfileDropdown $isDrop={isDrop} src={dropSrc} />
       <Droppable $isDrop={isDrop}></Droppable>

--- a/src/components/header/LoginProfile.tsx
+++ b/src/components/header/LoginProfile.tsx
@@ -1,15 +1,68 @@
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+import { kakaoInfoState } from '../../recoil/atom';
+import { useState } from 'react';
+
+import dropSrc from '/assets/images/header/dropdown-button.svg';
 
 const LoginProfile = () => {
+  const kakaoInfo = useRecoilValue(kakaoInfoState);
+  const [isDrop, setIsDrop] = useState(false);
+  const handleClick = () => {
+    setIsDrop((curr) => !curr);
+  };
   return (
-    <ProfileContainer>
-      <ProfileImg />
-      <ProfileName></ProfileName>
+    <ProfileContainer onClick={handleClick}>
+      <ProfileImg src={kakaoInfo.image} />
+      <ProfileName>{kakaoInfo.name}</ProfileName>
+      {/* 실제이름으로 변경하기 */}
+      <ProfileDropdown $isDrop={isDrop} src={dropSrc} />
+      <Droppable $isDrop={isDrop}></Droppable>
     </ProfileContainer>
   );
 };
-const ProfileContainer = styled.div``;
-const ProfileImg = styled.div``;
-const ProfileName = styled.div``;
+const ProfileContainer = styled.div`
+  position: relative;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+
+  color: ${(props) => props.theme.colors.primary90};
+  ${(props) => props.theme.fonts.subtitleM};
+
+  cursor: pointer;
+`;
+const ProfileImg = styled.img`
+  width: 3.6rem;
+  height: 3.6rem;
+  object-fit: cover;
+
+  border: 3px solid ${(props) => props.theme.colors.primary60};
+  border-radius: 1.8rem;
+`;
+const ProfileName = styled.div`
+  color: ${(props) => props.theme.colors.primary90};
+  ${(props) => props.theme.fonts.subtitleM};
+`;
+const ProfileDropdown = styled.img<{ $isDrop: boolean }>`
+  width: 1rem;
+  height: 0.5rem;
+  object-fit: cover;
+
+  transition: transform 0.5s ease;
+  transform: ${({ $isDrop }) => ($isDrop ? 'rotate(180deg)' : 'rotate(0)')};
+`;
+const Droppable = styled.div<{ $isDrop: boolean }>`
+  position: absolute;
+
+  left: 0;
+  top: 8.2rem;
+  width: 20rem;
+  height: ${(props) => (props.$isDrop ? '20rem' : 0)};
+  transition: height 0.3s ease-in-out;
+  background-color: wheat;
+`;
 
 export default LoginProfile;

--- a/src/components/join/SelectInput.tsx
+++ b/src/components/join/SelectInput.tsx
@@ -31,7 +31,7 @@ const SelectInput = ({
   return (
     <SelectContainer>
       <Label>활동 지역</Label>
-      <Select onChange={handleChange} name="region">
+      <Select onChange={handleChange} name="location">
         {REGIONS.map((each, idx) => (
           <Option key={idx} value={idx}>
             {each}

--- a/src/components/join/SelectInput.tsx
+++ b/src/components/join/SelectInput.tsx
@@ -1,13 +1,39 @@
 import styled from 'styled-components';
 import { REGIONS } from '../../constants/Join';
+import { InputDataArray } from '../../interface/Join';
 
-const SelectInput = ({ onChangeFunc }: { onChangeFunc: any }) => {
+const SelectInput = ({
+  onChangeFunc,
+  buttonActiveSetFunc,
+  index,
+}: {
+  onChangeFunc: any;
+  buttonActiveSetFunc: any;
+  index: number;
+}) => {
+  const handleChange = (event: any) => {
+    onChangeFunc(event);
+    // console.log(event.target.value);
+    if (event.target.value > 0)
+      buttonActiveSetFunc((curr: InputDataArray) => {
+        const newArr = [...curr];
+        newArr[index] = true;
+        return newArr;
+      });
+    else {
+      buttonActiveSetFunc((curr: InputDataArray) => {
+        const newArr = [...curr];
+        newArr[index] = false;
+        return newArr;
+      });
+    }
+  };
   return (
     <SelectContainer>
       <Label>활동 지역</Label>
-      <Select onChange={onChangeFunc} name="region">
+      <Select onChange={handleChange} name="region">
         {REGIONS.map((each, idx) => (
-          <Option key={idx} value={each}>
+          <Option key={idx} value={idx}>
             {each}
           </Option>
         ))}

--- a/src/components/join/TextAreaInput.tsx
+++ b/src/components/join/TextAreaInput.tsx
@@ -1,19 +1,35 @@
 import styled from 'styled-components';
-import { InputProps } from '../../interface/Join';
+import { InputDataArray, InputProps } from '../../interface/Join';
 import React, { useState } from 'react';
-import ErrorMessage from './ErrorMessage';
 
 const TextAreaInput = ({
   inputProps,
   onChangeFunc,
+  buttonActiveSetFunc,
+  index,
 }: {
   inputProps: InputProps;
   onChangeFunc: any;
+  buttonActiveSetFunc: any;
+  index: number;
 }) => {
-  const MIN_LENGTH = 10;
   const MAX_LENGTH = 140;
   const [text, setText] = useState('');
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (event.target.value.length > 0)
+      buttonActiveSetFunc((curr: InputDataArray) => {
+        const newArr = [...curr];
+        newArr[index] = true;
+        return newArr;
+      });
+    else {
+      buttonActiveSetFunc((curr: InputDataArray) => {
+        const newArr = [...curr];
+        newArr[index] = false;
+        return newArr;
+      });
+    }
+
     setText(event.target.value);
     onChangeFunc(event);
   };
@@ -23,14 +39,12 @@ const TextAreaInput = ({
       <Input
         placeholder={inputProps.placeholder}
         onChange={handleChange}
-        minLength={MIN_LENGTH}
         maxLength={MAX_LENGTH}
         name={inputProps.elemName}
       ></Input>
       <LengthCount>
         {text.length}/{MAX_LENGTH}
       </LengthCount>
-      <ErrorMessage errorText={inputProps.errorText} />
     </InputContainer>
   );
 };

--- a/src/components/join/TextInput.tsx
+++ b/src/components/join/TextInput.tsx
@@ -1,24 +1,42 @@
 import styled from 'styled-components';
-import { InputProps } from '../../interface/Join';
-import ErrorMessage from './ErrorMessage';
+import { InputDataArray, InputProps } from '../../interface/Join';
 
 const TextInput = ({
   inputProps,
   onChangeFunc,
+  buttonActiveSetFunc,
+  index,
 }: {
   inputProps: InputProps;
   onChangeFunc: any;
+  buttonActiveSetFunc: any;
+  index: number;
 }) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value.length > 0)
+      buttonActiveSetFunc((curr: InputDataArray) => {
+        const newArr = [...curr];
+        newArr[index] = true;
+        return newArr;
+      });
+    else {
+      buttonActiveSetFunc((curr: InputDataArray) => {
+        const newArr = [...curr];
+        newArr[index] = false;
+        return newArr;
+      });
+      onChangeFunc(event);
+    }
+  };
   return (
     <InputContainer>
       <Label>{inputProps.label}</Label>
       <Input
-        onChange={onChangeFunc}
+        onChange={handleChange}
         type="text"
         placeholder={inputProps.placeholder}
         name={inputProps.elemName}
       ></Input>
-      <ErrorMessage errorText={inputProps.errorText} />
     </InputContainer>
   );
 };

--- a/src/components/join/TextInput.tsx
+++ b/src/components/join/TextInput.tsx
@@ -25,8 +25,8 @@ const TextInput = ({
         newArr[index] = false;
         return newArr;
       });
-      onChangeFunc(event);
     }
+    onChangeFunc(event);
   };
   return (
     <InputContainer>

--- a/src/components/login/KakaoLogin.tsx
+++ b/src/components/login/KakaoLogin.tsx
@@ -1,5 +1,10 @@
 // import kakaoLoginImageSrc from '/assets/images/header/kakaoLogin.png';
 
+import { AxiosResponse } from 'axios';
+import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
+import { ResponseLogin } from '../../interface/Join';
+import { LoginResult } from '../../interface/Login';
+
 export const kakao = (window as any).Kakao;
 
 export const kakaoAuthorize = () => {
@@ -8,6 +13,31 @@ export const kakaoAuthorize = () => {
     redirectUri: `${redirectUri}`,
     scope: 'profile_nickname,profile_image,account_email,account_email',
   });
+
+  
+};
+
+export const loginWithKakaoToken = async (kakaoAccessToken: string) => {
+  try {
+    const responseLogin: AxiosResponse<ResponseLogin> =
+      await postLoginWithKakaoToken(kakaoAccessToken);
+    console.log('loginWithKakaoToken Complete', responseLogin);
+
+    //성공시
+    const loginResult: LoginResult = {
+      isSuccess: true,
+      statusCode: responseLogin.status,
+    };
+    return loginResult;
+  } catch (error: any) {
+    console.log('loginWithKakaoToken Error', error);
+    const loginResult: LoginResult = {
+      isSuccess: false,
+      statusCode: error.response?.data.status,
+      error: error,
+    };
+    return loginResult;
+  }
 };
 
 // const KakaoLogin = () => {

--- a/src/components/login/KakaoLogin.tsx
+++ b/src/components/login/KakaoLogin.tsx
@@ -2,7 +2,6 @@
 
 export const kakao = (window as any).Kakao;
 
-
 export const kakaoAuthorize = () => {
   const redirectUri = 'http://localhost:5173/login/oauth';
   kakao.Auth.authorize({
@@ -11,18 +10,18 @@ export const kakaoAuthorize = () => {
   });
 };
 
-const KakaoLogin = () => {
-  const redirectUri = 'http://localhost:5173/login/oauth';
-  return (
-    <div
-      // src={kakaoLoginImageSrc}
-      onClick={() =>
-        kakao.Auth.authorize({
-          redirectUri: `${redirectUri}`,
-          scope: 'profile_nickname,profile_image,account_email,account_email',
-        })
-      }
-    >마이페이지</div>
-  );
-};
-export default KakaoLogin;
+// const KakaoLogin = () => {
+//   const redirectUri = 'http://localhost:5173/login/oauth';
+//   return (
+//     <div
+//       // src={kakaoLoginImageSrc}
+//       onClick={() =>
+//         kakao.Auth.authorize({
+//           redirectUri: `${redirectUri}`,
+//           scope: 'profile_nickname,profile_image,account_email,account_email',
+//         })
+//       }
+//     >마이페이지</div>
+//   );
+// };
+// export default KakaoLogin;

--- a/src/components/login/KakaoLogin.tsx
+++ b/src/components/login/KakaoLogin.tsx
@@ -2,8 +2,7 @@
 
 import { AxiosResponse } from 'axios';
 import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
-import { ResponseLogin } from '../../interface/Join';
-import { LoginResult } from '../../interface/Login';
+import { LoginResult, ResponseLogin } from '../../interface/Login';
 
 export const kakao = (window as any).Kakao;
 
@@ -13,8 +12,6 @@ export const kakaoAuthorize = () => {
     redirectUri: `${redirectUri}`,
     scope: 'profile_nickname,profile_image,account_email,account_email',
   });
-
-  
 };
 
 export const loginWithKakaoToken = async (kakaoAccessToken: string) => {
@@ -27,8 +24,11 @@ export const loginWithKakaoToken = async (kakaoAccessToken: string) => {
     const loginResult: LoginResult = {
       isSuccess: true,
       statusCode: responseLogin.status,
+      responseData: responseLogin.data, //???타입에러 왜 안나지 data.data
     };
     return loginResult;
+
+    //실패시
   } catch (error: any) {
     console.log('loginWithKakaoToken Error', error);
     const loginResult: LoginResult = {

--- a/src/constants/Header.ts
+++ b/src/constants/Header.ts
@@ -2,6 +2,7 @@ export enum Headers {
   none = 'none',
   list = 'list',
   myTeam = 'myTeam',
+  myProfile = 'myProfile',
   login = 'login',
-  myPage = 'myPage',
+  
 }

--- a/src/constants/Join.ts
+++ b/src/constants/Join.ts
@@ -7,6 +7,7 @@ export enum ERROR_MESSAGES {
 }
 
 export const REGIONS = [
+  '선택해주세요',
   '서울특별시',
   '인천광역시',
   '대전광역시',

--- a/src/constants/Join.ts
+++ b/src/constants/Join.ts
@@ -30,7 +30,7 @@ export const INPUT_PROPS: InputProps[] = [
     label: '이름',
     placeholder: '이름을 입력해주세요',
     errorText: ERROR_MESSAGES.이름,
-    elemName: 'name',
+    elemName: 'username',
   },
   {
     label: '전공',
@@ -42,12 +42,12 @@ export const INPUT_PROPS: InputProps[] = [
     label: '희망 직무',
     placeholder: '희망 직무를 입력해주세요',
     errorText: ERROR_MESSAGES.희망직무,
-    elemName: 'part',
+    elemName: 'task',
   },
   {
     label: '한줄 소개',
     placeholder: '한줄 소개를 입력해주세요',
     errorText: ERROR_MESSAGES.한줄소개,
-    elemName: 'introduce',
+    elemName: 'selfIntroduce',
   },
 ];

--- a/src/hooks/useLoginWithKakaoToken.tsx
+++ b/src/hooks/useLoginWithKakaoToken.tsx
@@ -1,0 +1,45 @@
+import { useSetRecoilState } from 'recoil';
+import { loginWithKakaoToken } from '../components/login/KakaoLogin';
+import { LoginResult } from '../interface/Login';
+import { loginInfoState } from '../recoil/atom';
+import { useNavigate } from 'react-router-dom';
+
+/** 카카오 어세스 토큰를 통해 로그인 하는 훅
+ *
+ */
+const useLoginWithKakaoToken = () => {
+  // const loginResponse: LoginResult = loginWithKakaoToken(kakaoAccessToken);
+  const navigate = useNavigate();
+  const setLoginInfo = useSetRecoilState(loginInfoState);
+  const handleLogin = async (kakaoAccessToken: string) => {
+    try {
+      const responseLogin: LoginResult = await loginWithKakaoToken(
+        kakaoAccessToken,
+      );
+      if (responseLogin.isSuccess && responseLogin.responseData !== undefined) {
+        console.log('로그인성공', responseLogin);
+        setLoginInfo({
+          isLogin: true,
+          data: {
+            userId: responseLogin.responseData?.data?.userId,
+            refreshToken: responseLogin.responseData?.data.refreshToken,
+            accessToken: responseLogin.responseData?.data.accessToken,
+            profileImage: responseLogin.responseData?.data.profileImage,
+            name: responseLogin.responseData?.data.name,
+          },
+        });
+      } else {
+        if (responseLogin.statusCode == 404) {
+          console.log('로그인실패 회원이 아님', responseLogin);
+          navigate('/login/join');
+        } else {
+          console.log('로그인실패, 이거 출력되면 안되는데', responseLogin);
+        }
+      }
+    } catch (error: any) {
+      console.error('UN EXPECTED ERROR Login failed:', error);
+    }
+  };
+  return { handleLogin };
+};
+export default useLoginWithKakaoToken;

--- a/src/hooks/useLoginWithKakaoToken.tsx
+++ b/src/hooks/useLoginWithKakaoToken.tsx
@@ -18,6 +18,7 @@ const useLoginWithKakaoToken = () => {
       );
       if (responseLogin.isSuccess && responseLogin.responseData !== undefined) {
         console.log('로그인성공', responseLogin);
+
         setLoginInfo({
           isLogin: true,
           data: {
@@ -28,6 +29,7 @@ const useLoginWithKakaoToken = () => {
             name: responseLogin.responseData?.data.name,
           },
         });
+        navigate('/');
       } else {
         if (responseLogin.statusCode == 404) {
           console.log('로그인실패 회원이 아님', responseLogin);

--- a/src/interface/Join.ts
+++ b/src/interface/Join.ts
@@ -13,15 +13,3 @@ export interface RequestJoin {
   kakaoAccessToken: string; //토큰
 }
 export type InputDataArray = [boolean, boolean, boolean, boolean, boolean];
-export interface ResponseLogin {
-  status: number;
-  message: string;
-  data: {
-    userId: number;
-    redirectUrl: string;
-    refreshToken: string;
-    accessToken: string;
-    profileImage: string;
-    name: string;
-  };
-}

--- a/src/interface/Join.ts
+++ b/src/interface/Join.ts
@@ -10,5 +10,18 @@ export interface RequestJoin {
   major: string; //전공
   task: string; //희망직무
   selfIntroduce: string; //한줄소개
+  kakaoAccessToken: string; //토큰
 }
 export type InputDataArray = [boolean, boolean, boolean, boolean, boolean];
+export interface ResponseLogin {
+  status: number;
+  message: string;
+  data: {
+    userId: number;
+    redirectUrl: string;
+    refreshToken: string;
+    accessToken: string;
+    profileImage: string;
+    name: string;
+  };
+}

--- a/src/interface/Join.ts
+++ b/src/interface/Join.ts
@@ -5,11 +5,10 @@ export interface InputProps {
   elemName: string;
 }
 export interface RequestJoin {
-  name: string; //이름
-  region: string; //활동지역
+  username: string; //이름
+  location: string; //활동지역
   major: string; //전공
-  part: string; //희망직무
-  introduce: string; //한줄소개
-  email: string; //카카오이메일
+  task: string; //희망직무
+  selfIntroduce: string; //한줄소개
 }
 export type InputDataArray = [boolean, boolean, boolean, boolean, boolean];

--- a/src/interface/Join.ts
+++ b/src/interface/Join.ts
@@ -12,3 +12,4 @@ export interface RequestJoin {
   introduce: string; //한줄소개
   email: string; //카카오이메일
 }
+export type InputDataArray = [boolean, boolean, boolean, boolean, boolean];

--- a/src/interface/Kakao.ts
+++ b/src/interface/Kakao.ts
@@ -1,5 +1,4 @@
 export interface KakaoInfo {
   name: string;
   image: string;
-  email: string;
 }

--- a/src/interface/Kakao.ts
+++ b/src/interface/Kakao.ts
@@ -1,0 +1,5 @@
+export interface KakaoInfo {
+  name: string;
+  image: string;
+  email: string;
+}

--- a/src/interface/Login.ts
+++ b/src/interface/Login.ts
@@ -1,0 +1,10 @@
+export interface LoginInfo {
+  isLogin: boolean;
+  data?: {
+    userId: number;
+    refreshToken: string;
+    accessToken: string;
+    profileImage: string;
+    name: string;
+  };
+}

--- a/src/interface/Login.ts
+++ b/src/interface/Login.ts
@@ -8,9 +8,22 @@ export interface LoginInfo {
     name: string;
   };
 }
+export interface ResponseLogin {
+  status: number;
+  message: string;
+  data: {
+    userId: number;
+    redirectUrl: string;
+    refreshToken: string;
+    accessToken: string;
+    profileImage: string;
+    name: string;
+  };
+}
 
 export interface LoginResult {
   isSuccess: boolean;
   statusCode: number;
+  responseData?: ResponseLogin;
   error?: any;
 }

--- a/src/interface/Login.ts
+++ b/src/interface/Login.ts
@@ -8,3 +8,9 @@ export interface LoginInfo {
     name: string;
   };
 }
+
+export interface LoginResult {
+  isSuccess: boolean;
+  statusCode: number;
+  error?: any;
+}

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import React, { useEffect, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
-import { headerSelectedState, loginState } from '../../recoil/atom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { headerSelectedState, kakaoAccessTokenState } from '../../recoil/atom';
 import { Headers } from '../../constants/Header';
 
 import bgSrc from '/assets/images/join/join-bg.png';
@@ -18,8 +18,8 @@ const Join = () => {
   //navigate의 state로 온 토큰을 받기 위함
   //이게 아니고, 스토리지에서 꺼내서 확인하는 로직이 되어야 할듯
   const navigate = useNavigate();
-  const kakaoAccessToken = localStorage.getItem('kakaoAccessToken');
-  const setIsLoginState = useSetRecoilState(loginState);
+  const kakaoAccessToken = useRecoilValue(kakaoAccessTokenState);
+  // const setLoginInfo = useSetRecoilState(loginInfoState);
   const [inputValue, setInputValue] = useState<RequestJoin>({
     username: '민정리',
     location: '서울특별시',
@@ -44,7 +44,7 @@ const Join = () => {
         kakaoAccessToken: kakaoAccessToken as string,
       });
       console.log('responseJoin 결과:', responseJoin);
-      setIsLoginState(true);
+      loginWithKakaoToken(kakaoAccessToken)
       navigate('/');
     } catch (error) {
       console.log('responseJoin 실패:', error);

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -19,12 +19,11 @@ const Join = () => {
   //const location = useLocation();
   //const kakaoAccessToken = location.state.kakaoAccessToken;
   const [inputValue, setInputValue] = useState<RequestJoin>({
-    name: '민정리',
-    region: '서울특별시',
+    username: '민정리',
+    location: '서울특별시',
     major: '미디어뭐더라',
-    part: 'IT/희망직종',
-    introduce: '감자맛있단다',
-    email: 'minjeong@legend.gosu',
+    task: 'IT/희망직종',
+    selfIntroduce: '감자맛있단다',
   });
   const [buttonActiveCount, setButtonActiveCount] = useState<InputDataArray>([
     false,
@@ -54,7 +53,6 @@ const Join = () => {
       const newObj: RequestJoin = { ...curr };
       const keyName = event.target.name as keyof RequestJoin;
       newObj[keyName] = event.target.value;
-      console.log(newObj);
       return newObj;
     });
   };

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -13,13 +13,14 @@ import TextAreaInput from '../../components/join/TextAreaInput';
 import { InputDataArray, RequestJoin } from '../../interface/Join';
 import postJoin from '../../apis/join/postJoin';
 import { useNavigate } from 'react-router-dom';
+import useLoginWithKakaoToken from '../../hooks/useLoginWithKakaoToken';
 
 const Join = () => {
   //navigate의 state로 온 토큰을 받기 위함
   //이게 아니고, 스토리지에서 꺼내서 확인하는 로직이 되어야 할듯
   const navigate = useNavigate();
   const kakaoAccessToken = useRecoilValue(kakaoAccessTokenState);
-  // const setLoginInfo = useSetRecoilState(loginInfoState);
+  const { handleLogin } = useLoginWithKakaoToken();
   const [inputValue, setInputValue] = useState<RequestJoin>({
     username: '민정리',
     location: '서울특별시',
@@ -43,13 +44,17 @@ const Join = () => {
         ...inputValue,
         kakaoAccessToken: kakaoAccessToken as string,
       });
-      console.log('responseJoin 결과:', responseJoin);
-      // loginWithKakaoToken(kakaoAccessToken)
+      console.log('responseJoin 결과 성공:', responseJoin);
+
+      // 바로 즉시 로그인
+      handleLogin(kakaoAccessToken);
+
       navigate('/');
     } catch (error) {
       console.log('responseJoin 실패:', error);
     }
   };
+
   const handleChange = (
     // event: React.FormEvent<
     //   HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -10,7 +10,7 @@ import TextInput from '../../components/join/TextInput';
 import { INPUT_PROPS } from '../../constants/Join';
 import SelectInput from '../../components/join/SelectInput';
 import TextAreaInput from '../../components/join/TextAreaInput';
-import { RequestJoin } from '../../interface/Join';
+import { InputDataArray, RequestJoin } from '../../interface/Join';
 
 const Join = () => {
   //navigate의 state로 온 토큰을 받기 위함
@@ -26,6 +26,13 @@ const Join = () => {
     introduce: '감자맛있단다',
     email: 'minjeong@legend.gosu',
   });
+  const [buttonActiveCount, setButtonActiveCount] = useState<InputDataArray>([
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     console.log(inputValue);
@@ -51,7 +58,10 @@ const Join = () => {
       return newObj;
     });
   };
-
+  const isAcvivateButton = (buttonActiveArr: InputDataArray) => {
+    if (buttonActiveArr.every((value) => value === true)) return true;
+    else return false;
+  };
   const setHeaderSelected = useSetRecoilState(headerSelectedState);
   useEffect(() => setHeaderSelected(Headers.login));
 
@@ -62,23 +72,48 @@ const Join = () => {
           <TitleStarImg src={starSrc} />
           <TitleText>똑똑한 회원님의 정보를 알려주세요!</TitleText>
         </TitleBox>
-        <TextInput onChangeFunc={handleChange} inputProps={INPUT_PROPS[0]} />
-        <SelectInput onChangeFunc={handleChange} />
-        <TextInput onChangeFunc={handleChange} inputProps={INPUT_PROPS[1]} />
-        <TextInput onChangeFunc={handleChange} inputProps={INPUT_PROPS[2]} />
+        <TextInput
+          buttonActiveSetFunc={setButtonActiveCount}
+          onChangeFunc={handleChange}
+          inputProps={INPUT_PROPS[0]}
+          index={0}
+        />
+        <SelectInput
+          buttonActiveSetFunc={setButtonActiveCount}
+          onChangeFunc={handleChange}
+          index={1}
+        />
+        <TextInput
+          buttonActiveSetFunc={setButtonActiveCount}
+          onChangeFunc={handleChange}
+          inputProps={INPUT_PROPS[1]}
+          index={2}
+        />
+        <TextInput
+          buttonActiveSetFunc={setButtonActiveCount}
+          onChangeFunc={handleChange}
+          inputProps={INPUT_PROPS[2]}
+          index={3}
+        />
         <TextAreaInput
+          buttonActiveSetFunc={setButtonActiveCount}
           onChangeFunc={handleChange}
           inputProps={INPUT_PROPS[3]}
+          index={4}
         />
 
-        <StartButton type="submit">원팀 시작하기 →</StartButton>
+        <StartButton
+          type="submit"
+          $isActive={isAcvivateButton(buttonActiveCount)}
+        >
+          원팀 시작하기 →
+        </StartButton>
       </JoinFormContainer>
     </JoinLayout>
   );
 };
 
 export default Join;
-
 const JoinLayout = styled.div`
   width: 100%;
   height: 100%; //수정 필요
@@ -125,14 +160,23 @@ const TitleText = styled.div`
   ${(props) => props.theme.fonts.heading4};
   color: ${(props) => props.theme.colors.gray90};
 `;
-const StartButton = styled.button`
+const StartButton = styled.button<{ $isActive: boolean }>`
   width: 25.5rem;
   height: 6.4rem;
 
   border-radius: 3.2rem;
-  border: 1px solid ${(props) => props.theme.colors.primary20};
-  background-color: ${(props) => props.theme.colors.primary60};
+  border: 1px solid
+    ${(props) =>
+      props.$isActive
+        ? props.theme.colors.primary20
+        : props.theme.colors.gray50};
+
+  background-color: ${(props) =>
+    props.$isActive ? props.theme.colors.primary60 : props.theme.colors.gray10};
 
   ${(props) => props.theme.fonts.buttonL};
-  color: ${(props) => props.theme.colors.white};
+  color: ${(props) =>
+    props.$isActive ? props.theme.colors.white : props.theme.colors.gray40};
+
+  cursor: ${(props) => (props.$isActive ? 'pointer' : 'default')};
 `;

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -11,19 +11,21 @@ import { INPUT_PROPS } from '../../constants/Join';
 import SelectInput from '../../components/join/SelectInput';
 import TextAreaInput from '../../components/join/TextAreaInput';
 import { InputDataArray, RequestJoin } from '../../interface/Join';
+import postJoin from '../../apis/join/postJoin';
 
 const Join = () => {
   //navigate의 state로 온 토큰을 받기 위함
   //이게 아니고, 스토리지에서 꺼내서 확인하는 로직이 되어야 할듯
 
   //const location = useLocation();
-  //const kakaoAccessToken = location.state.kakaoAccessToken;
+  const kakaoAccessToken = localStorage.getItem('kakaoAccessToken');
   const [inputValue, setInputValue] = useState<RequestJoin>({
     username: '민정리',
     location: '서울특별시',
     major: '미디어뭐더라',
     task: 'IT/희망직종',
     selfIntroduce: '감자맛있단다',
+    kakaoAccessToken: 'noToken',
   });
   const [buttonActiveCount, setButtonActiveCount] = useState<InputDataArray>([
     false,
@@ -34,14 +36,16 @@ const Join = () => {
   ]);
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    console.log(inputValue);
-    // console.log(kakaoAccessToken);
-    // try {
-    //   const responseJoin = await postJoin(kakaoAccessToken, inputValue);
-    //   console.log('responseJoin 결과:', responseJoin);
-    // } catch (error) {
-    //   console.log('responseJoin 실패:', error);
-    // }
+    console.log({ ...inputValue, kakaoAccessToken: kakaoAccessToken });
+    try {
+      const responseJoin = await postJoin({
+        ...inputValue,
+        kakaoAccessToken: kakaoAccessToken as string,
+      });
+      console.log('responseJoin 결과:', responseJoin);
+    } catch (error) {
+      console.log('responseJoin 실패:', error);
+    }
   };
   const handleChange = (
     // event: React.FormEvent<

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import React, { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { headerSelectedState } from '../../recoil/atom';
+import { headerSelectedState, loginState } from '../../recoil/atom';
 import { Headers } from '../../constants/Header';
 
 import bgSrc from '/assets/images/join/join-bg.png';
@@ -12,13 +12,14 @@ import SelectInput from '../../components/join/SelectInput';
 import TextAreaInput from '../../components/join/TextAreaInput';
 import { InputDataArray, RequestJoin } from '../../interface/Join';
 import postJoin from '../../apis/join/postJoin';
+import { useNavigate } from 'react-router-dom';
 
 const Join = () => {
   //navigate의 state로 온 토큰을 받기 위함
   //이게 아니고, 스토리지에서 꺼내서 확인하는 로직이 되어야 할듯
-
-  //const location = useLocation();
+  const navigate = useNavigate();
   const kakaoAccessToken = localStorage.getItem('kakaoAccessToken');
+  const setIsLoginState = useSetRecoilState(loginState);
   const [inputValue, setInputValue] = useState<RequestJoin>({
     username: '민정리',
     location: '서울특별시',
@@ -43,6 +44,8 @@ const Join = () => {
         kakaoAccessToken: kakaoAccessToken as string,
       });
       console.log('responseJoin 결과:', responseJoin);
+      setIsLoginState(true);
+      navigate('/');
     } catch (error) {
       console.log('responseJoin 실패:', error);
     }

--- a/src/pages/join/Join.tsx
+++ b/src/pages/join/Join.tsx
@@ -44,7 +44,7 @@ const Join = () => {
         kakaoAccessToken: kakaoAccessToken as string,
       });
       console.log('responseJoin 결과:', responseJoin);
-      loginWithKakaoToken(kakaoAccessToken)
+      // loginWithKakaoToken(kakaoAccessToken)
       navigate('/');
     } catch (error) {
       console.log('responseJoin 실패:', error);

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -3,21 +3,24 @@ import bgSrc from '/assets/images/login/login-bg.svg';
 import btnSrc from '/assets/images/login/login-button.svg';
 import {
   kakaoAuthorize,
-  loginWithKakaoToken,
+  // loginWithKakaoToken,
 } from '../../components/login/KakaoLogin';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { headerSelectedState, kakaoAccessTokenState } from '../../recoil/atom';
 import { useEffect } from 'react';
 import { Headers } from '../../constants/Header';
+import useLoginWithKakaoToken from '../../hooks/useLoginWithKakaoToken';
 
 const Login = () => {
   const setHeaderSelected = useSetRecoilState(headerSelectedState);
   const kakaoAccessToken = useRecoilValue(kakaoAccessTokenState);
+  const { handleLogin } = useLoginWithKakaoToken();
   useEffect(() => setHeaderSelected(Headers.login));
+  
   const handleClick = () => {
     if (kakaoAccessToken) {
       console.log('kakao토큰보유중', kakaoAccessToken);
-      loginWithKakaoToken(kakaoAccessToken);
+      handleLogin(kakaoAccessToken);
     } else {
       kakaoAuthorize();
     }

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,16 +1,27 @@
 import styled from 'styled-components';
 import bgSrc from '/assets/images/login/login-bg.svg';
 import btnSrc from '/assets/images/login/login-button.svg';
-import { kakaoAuthorize } from '../../components/login/KakaoLogin';
-import { useSetRecoilState } from 'recoil';
-import { headerSelectedState } from '../../recoil/atom';
+import {
+  kakaoAuthorize,
+  loginWithKakaoToken,
+} from '../../components/login/KakaoLogin';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { headerSelectedState, kakaoAccessTokenState } from '../../recoil/atom';
 import { useEffect } from 'react';
 import { Headers } from '../../constants/Header';
 
 const Login = () => {
-  
   const setHeaderSelected = useSetRecoilState(headerSelectedState);
+  const kakaoAccessToken = useRecoilValue(kakaoAccessTokenState);
   useEffect(() => setHeaderSelected(Headers.login));
+  const handleClick = () => {
+    if (kakaoAccessToken) {
+      console.log('kakao토큰보유중', kakaoAccessToken);
+      loginWithKakaoToken(kakaoAccessToken);
+    } else {
+      kakaoAuthorize();
+    }
+  };
   return (
     <LoginLayout>
       <LoginTextContainer>
@@ -19,7 +30,7 @@ const Login = () => {
           <span>{'똑똑한 팀 모집'}</span>
           {'을 시작해보세요'}
         </div>
-        <LoginButton src={btnSrc} onClick={kakaoAuthorize} />
+        <LoginButton src={btnSrc} onClick={handleClick} />
       </LoginTextContainer>
       <LoginBgImg src={bgSrc} />
     </LoginLayout>

--- a/src/pages/login/Oauth.tsx
+++ b/src/pages/login/Oauth.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import fetchKakaoAccessToken from '../../apis/login/postKakaoAccessToken';
 import { kakao } from '../../components/login/KakaoLogin';
 import fetchKakaoUserInfo from '../../apis/login/getKakaoUserInfo';
 import { useSetRecoilState } from 'recoil';
@@ -8,24 +7,26 @@ import { useNavigate } from 'react-router-dom';
 import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
 import { ResponseLogin } from '../../interface/Join';
 import { AxiosResponse } from 'axios';
+import postKakaoAccessTokenFromCode from '../../apis/login/postKakaoAccessTokenFromCode';
 
 const Oauth = () => {
   const setKakaoAccessTokenState = useSetRecoilState(kakaoAccessTokenState);
   const setKakaoInfoState = useSetRecoilState(kakaoInfoState);
   // const setloginState = useSetRecoilState(loginState);
   const navigate = useNavigate();
+
+
   /** 카카오 인가 코드를 통해 카카오 어세스 토큰을 받아오는 함수
    *
    * @param kakaoAccessCode 로그인 후 받아온 카카오 인가  코드
    */
-  const getKakaoAccessToken = async (kakaoAccessCode: string) => {
+  const getKakaoAccessTokenWithCode = async (kakaoAccessCode: string) => {
     try {
-      const responseKakaoAccessCode = await fetchKakaoAccessToken(
+      const responseKakaoAccessCode = await postKakaoAccessTokenFromCode(
         kakaoAccessCode,
       );
-      console.log('getKakaoAccessTokencomplete', responseKakaoAccessCode);
+      console.log('인가코드로 accesstoken 받기 성공', responseKakaoAccessCode);
       setKakaoAccessTokenState(responseKakaoAccessCode.data.access_token);
-      // setloginState(true);
       localStorage.setItem(
         'kakaoAccessToken',
         responseKakaoAccessCode.data.access_token,
@@ -42,7 +43,7 @@ const Oauth = () => {
 
       return responseKakaoAccessCode.data.access_token;
     } catch (error) {
-      console.log('kakaoAccessToken', error);
+      console.log('getKakaoAccessTokenWithCode', error);
     }
   };
 
@@ -71,13 +72,14 @@ const Oauth = () => {
     try {
       const responseLogin: AxiosResponse<ResponseLogin> =
         await postLoginWithKakaoToken(kakaoAccessToken);
-      console.log('responseValitadion Complete', responseLogin);
+      console.log('loginWithKakaoToken Complete', responseLogin);
       setKakaoInfoState({
         name: responseLogin.data.data.name,
         image: responseLogin.data.data.profileImage,
       });
     } catch (error: any) {
-      //console.log('카카오토큰 validation 에러', error);
+      console.log('loginWithKakaoToken Error', error);
+      //여기에 setlogin하면 될듯
       //회원가입 페이지로 연결
       if (error.response.data.status == 404) {
         navigate('/login/join', {
@@ -87,18 +89,11 @@ const Oauth = () => {
     }
   };
 
-  // const maintainLoginWithToken = (kakaoAccessToken: string) => {
-  //   kakao.Auth.setAccessToken(kakaoAccessToken);
-  //   console.log('새로고침해도그대로라구');
-  // };
+ 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const kakaoAccessCode = params.get('code');
-
-    // const localStorageKakaoToken = localStorage.getItem('kakaoAccessToken');
-    //if (localStorageKakaoToken) maintainLoginWithToken(localStorageKakaoToken);
-
-    const kakaoAccessToken = getKakaoAccessToken(kakaoAccessCode as string);
+    const kakaoAccessToken = getKakaoAccessTokenWithCode(kakaoAccessCode as string);
     kakaoAccessToken;
     //우리팀 서버에 카카오 토큰 유효성 검증하기
 

--- a/src/pages/login/Oauth.tsx
+++ b/src/pages/login/Oauth.tsx
@@ -2,16 +2,16 @@ import { useEffect } from 'react';
 import { kakao } from '../../components/login/KakaoLogin';
 import fetchKakaoUserInfo from '../../apis/login/getKakaoUserInfo';
 import { useSetRecoilState } from 'recoil';
-import { kakaoAccessTokenState, loginInfoState } from '../../recoil/atom';
+import { kakaoAccessTokenState } from '../../recoil/atom';
 import { useNavigate } from 'react-router-dom';
-import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
-import { ResponseLogin } from '../../interface/Join';
-import { AxiosResponse } from 'axios';
+
 import postKakaoAccessTokenFromCode from '../../apis/login/postKakaoAccessTokenFromCode';
+import useLoginWithKakaoToken from '../../hooks/useLoginWithKakaoToken';
 
 const Oauth = () => {
   const setKakaoAccessTokenState = useSetRecoilState(kakaoAccessTokenState);
-  const setLoginInfoState = useSetRecoilState(loginInfoState);
+  const { handleLogin } = useLoginWithKakaoToken();
+
   const navigate = useNavigate();
 
   /** 카카오 인가 코드를 통해 카카오 어세스 토큰을 받아오는 함수
@@ -33,7 +33,8 @@ const Oauth = () => {
       getKakaoUserInfo(responseKakaoAccessCode.data.access_token);
 
       //카카오토큰으로 로그인하기
-      loginWithKakaoToken(responseKakaoAccessCode.data.access_token);
+      handleLogin(responseKakaoAccessCode.data.access_token);
+      //loginWithKakaoToken(responseKakaoAccessCode.data.access_token);
 
       return responseKakaoAccessCode.data.access_token;
     } catch (error) {
@@ -54,37 +55,37 @@ const Oauth = () => {
     }
   };
 
-  /** 카카오 어세스 토큰를 통해 로그인 하는 함수
-   *
-   * @param kakaoAccessToken 카카오 어세스 토큰
-   */
-  const loginWithKakaoToken = async (kakaoAccessToken: string) => {
-    try {
-      const responseLogin: AxiosResponse<ResponseLogin> =
-        await postLoginWithKakaoToken(kakaoAccessToken);
-      console.log('loginWithKakaoToken Complete', responseLogin);
+  // /** 카카오 어세스 토큰를 통해 로그인 하는 함수
+  //  *
+  //  * @param kakaoAccessToken 카카오 어세스 토큰
+  //  */
+  // const loginWithKakaoToken = async (kakaoAccessToken: string) => {
+  //   try {
+  //     const responseLogin: AxiosResponse<ResponseLogin> =
+  //       await postLoginWithKakaoToken(kakaoAccessToken);
+  //     console.log('loginWithKakaoToken Complete', responseLogin);
 
-      setLoginInfoState({
-        isLogin: true,
-        data: {
-          userId: responseLogin.data.data.userId,
-          refreshToken: responseLogin.data.data.refreshToken,
-          accessToken: responseLogin.data.data.accessToken,
-          profileImage: responseLogin.data.data.profileImage,
-          name: responseLogin.data.data.name,
-        },
-      });
-    } catch (error: any) {
-      console.log('loginWithKakaoToken Error', error);
-      //여기에 setlogin하면 될듯
-      //회원가입 페이지로 연결
-      if (error.response.data.status == 404) {
-        navigate('/login/join', {
-          state: { kakaoAccessToken: kakaoAccessToken },
-        });
-      }
-    }
-  };
+  //     setLoginInfoState({
+  //       isLogin: true,
+  //       data: {
+  //         userId: responseLogin.data.data.userId,
+  //         refreshToken: responseLogin.data.data.refreshToken,
+  //         accessToken: responseLogin.data.data.accessToken,
+  //         profileImage: responseLogin.data.data.profileImage,
+  //         name: responseLogin.data.data.name,
+  //       },
+  //     });
+  //   } catch (error: any) {
+  //     console.log('loginWithKakaoToken Error', error);
+  //     //여기에 setlogin하면 될듯
+  //     //회원가입 페이지로 연결
+  //     if (error.response.data.status == 404) {
+  //       navigate('/login/join', {
+  //         state: { kakaoAccessToken: kakaoAccessToken },
+  //       });
+  //     }
+  //   }
+  // };
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);

--- a/src/pages/login/Oauth.tsx
+++ b/src/pages/login/Oauth.tsx
@@ -2,11 +2,7 @@ import { useEffect } from 'react';
 import { kakao } from '../../components/login/KakaoLogin';
 import fetchKakaoUserInfo from '../../apis/login/getKakaoUserInfo';
 import { useSetRecoilState } from 'recoil';
-import {
-  kakaoAccessTokenState,
-  kakaoInfoState,
-  loginState,
-} from '../../recoil/atom';
+import { kakaoAccessTokenState, loginInfoState } from '../../recoil/atom';
 import { useNavigate } from 'react-router-dom';
 import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
 import { ResponseLogin } from '../../interface/Join';
@@ -15,8 +11,7 @@ import postKakaoAccessTokenFromCode from '../../apis/login/postKakaoAccessTokenF
 
 const Oauth = () => {
   const setKakaoAccessTokenState = useSetRecoilState(kakaoAccessTokenState);
-  const setKakaoInfoState = useSetRecoilState(kakaoInfoState);
-  const setloginState = useSetRecoilState(loginState);
+  const setLoginInfoState = useSetRecoilState(loginInfoState);
   const navigate = useNavigate();
 
   /** 카카오 인가 코드를 통해 카카오 어세스 토큰을 받아오는 함수
@@ -30,10 +25,6 @@ const Oauth = () => {
       );
       console.log('인가코드로 accesstoken 받기 성공', responseKakaoAccessCode);
       setKakaoAccessTokenState(responseKakaoAccessCode.data.access_token);
-      localStorage.setItem(
-        'kakaoAccessToken',
-        responseKakaoAccessCode.data.access_token,
-      );
 
       //받아온 토큰을 setAcessToken하기
       kakao.Auth.setAccessToken(responseKakaoAccessCode.data.access_token);
@@ -58,10 +49,6 @@ const Oauth = () => {
     try {
       const responseUserInfo = await fetchKakaoUserInfo(kakaoAccessToken);
       console.log('responseUserInfo Complete', responseUserInfo);
-      setKakaoInfoState({
-        name: responseUserInfo.data.properties.nickname,
-        image: responseUserInfo.data.properties.profile_image,
-      });
     } catch (error) {
       console.log('카카오 정보 가져오기 에러', error);
     }
@@ -76,11 +63,17 @@ const Oauth = () => {
       const responseLogin: AxiosResponse<ResponseLogin> =
         await postLoginWithKakaoToken(kakaoAccessToken);
       console.log('loginWithKakaoToken Complete', responseLogin);
-      setKakaoInfoState({
-        name: responseLogin.data.data.name,
-        image: responseLogin.data.data.profileImage,
+
+      setLoginInfoState({
+        isLogin: true,
+        data: {
+          userId: responseLogin.data.data.userId,
+          refreshToken: responseLogin.data.data.refreshToken,
+          accessToken: responseLogin.data.data.accessToken,
+          profileImage: responseLogin.data.data.profileImage,
+          name: responseLogin.data.data.name,
+        },
       });
-      setloginState(true);
     } catch (error: any) {
       console.log('loginWithKakaoToken Error', error);
       //여기에 setlogin하면 될듯

--- a/src/pages/login/Oauth.tsx
+++ b/src/pages/login/Oauth.tsx
@@ -2,7 +2,11 @@ import { useEffect } from 'react';
 import { kakao } from '../../components/login/KakaoLogin';
 import fetchKakaoUserInfo from '../../apis/login/getKakaoUserInfo';
 import { useSetRecoilState } from 'recoil';
-import { kakaoAccessTokenState, kakaoInfoState } from '../../recoil/atom';
+import {
+  kakaoAccessTokenState,
+  kakaoInfoState,
+  loginState,
+} from '../../recoil/atom';
 import { useNavigate } from 'react-router-dom';
 import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
 import { ResponseLogin } from '../../interface/Join';
@@ -12,9 +16,8 @@ import postKakaoAccessTokenFromCode from '../../apis/login/postKakaoAccessTokenF
 const Oauth = () => {
   const setKakaoAccessTokenState = useSetRecoilState(kakaoAccessTokenState);
   const setKakaoInfoState = useSetRecoilState(kakaoInfoState);
-  // const setloginState = useSetRecoilState(loginState);
+  const setloginState = useSetRecoilState(loginState);
   const navigate = useNavigate();
-
 
   /** 카카오 인가 코드를 통해 카카오 어세스 토큰을 받아오는 함수
    *
@@ -77,6 +80,7 @@ const Oauth = () => {
         name: responseLogin.data.data.name,
         image: responseLogin.data.data.profileImage,
       });
+      setloginState(true);
     } catch (error: any) {
       console.log('loginWithKakaoToken Error', error);
       //여기에 setlogin하면 될듯
@@ -89,11 +93,12 @@ const Oauth = () => {
     }
   };
 
- 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const kakaoAccessCode = params.get('code');
-    const kakaoAccessToken = getKakaoAccessTokenWithCode(kakaoAccessCode as string);
+    const kakaoAccessToken = getKakaoAccessTokenWithCode(
+      kakaoAccessCode as string,
+    );
     kakaoAccessToken;
     //우리팀 서버에 카카오 토큰 유효성 검증하기
 

--- a/src/pages/login/Oauth.tsx
+++ b/src/pages/login/Oauth.tsx
@@ -5,7 +5,9 @@ import fetchKakaoUserInfo from '../../apis/login/getKakaoUserInfo';
 import { useSetRecoilState } from 'recoil';
 import { kakaoAccessTokenState, kakaoInfoState } from '../../recoil/atom';
 import { useNavigate } from 'react-router-dom';
-import postKakaoToken from '../../apis/login/postKakaoToken';
+import postLoginWithKakaoToken from '../../apis/login/postLoginWithKakaoToken';
+import { ResponseLogin } from '../../interface/Join';
+import { AxiosResponse } from 'axios';
 
 const Oauth = () => {
   const setKakaoAccessTokenState = useSetRecoilState(kakaoAccessTokenState);
@@ -35,8 +37,8 @@ const Oauth = () => {
       //카카오 access토큰으로 사용자 정보 가져오기
       getKakaoUserInfo(responseKakaoAccessCode.data.access_token);
 
-      //카카오토큰 유효성 검증
-      validateKakaoToken(responseKakaoAccessCode.data.access_token);
+      //카카오토큰으로 로그인하기
+      loginWithKakaoToken(responseKakaoAccessCode.data.access_token);
 
       return responseKakaoAccessCode.data.access_token;
     } catch (error) {
@@ -55,21 +57,25 @@ const Oauth = () => {
       setKakaoInfoState({
         name: responseUserInfo.data.properties.nickname,
         image: responseUserInfo.data.properties.profile_image,
-        email: responseUserInfo.data.kakao_account.email,
       });
     } catch (error) {
       console.log('카카오 정보 가져오기 에러', error);
     }
   };
 
-  /** 카카오 어세스 토큰를 통해 서버에 존재하는 회원인지 확인하는 함수
+  /** 카카오 어세스 토큰를 통해 로그인 하는 함수
    *
    * @param kakaoAccessToken 카카오 어세스 토큰
    */
-  const validateKakaoToken = async (kakaoAccessToken: string) => {
+  const loginWithKakaoToken = async (kakaoAccessToken: string) => {
     try {
-      const responseValitadion = await postKakaoToken(kakaoAccessToken);
-      console.log('responseValitadion Complete', responseValitadion);
+      const responseLogin: AxiosResponse<ResponseLogin> =
+        await postLoginWithKakaoToken(kakaoAccessToken);
+      console.log('responseValitadion Complete', responseLogin);
+      setKakaoInfoState({
+        name: responseLogin.data.data.name,
+        image: responseLogin.data.data.profileImage,
+      });
     } catch (error: any) {
       //console.log('카카오토큰 validation 에러', error);
       //회원가입 페이지로 연결

--- a/src/pages/login/Oauth.tsx
+++ b/src/pages/login/Oauth.tsx
@@ -3,13 +3,13 @@ import fetchKakaoAccessToken from '../../apis/login/postKakaoAccessToken';
 import { kakao } from '../../components/login/KakaoLogin';
 import fetchKakaoUserInfo from '../../apis/login/getKakaoUserInfo';
 import { useSetRecoilState } from 'recoil';
-import { kakaoAccessTokenState, kakaoNameState } from '../../recoil/atom';
+import { kakaoAccessTokenState, kakaoInfoState } from '../../recoil/atom';
 import { useNavigate } from 'react-router-dom';
 import postKakaoToken from '../../apis/login/postKakaoToken';
 
 const Oauth = () => {
   const setKakaoAccessTokenState = useSetRecoilState(kakaoAccessTokenState);
-  const setKakaoNameState = useSetRecoilState(kakaoNameState);
+  const setKakaoInfoState = useSetRecoilState(kakaoInfoState);
   // const setloginState = useSetRecoilState(loginState);
   const navigate = useNavigate();
   /** 카카오 인가 코드를 통해 카카오 어세스 토큰을 받아오는 함수
@@ -52,7 +52,11 @@ const Oauth = () => {
     try {
       const responseUserInfo = await fetchKakaoUserInfo(kakaoAccessToken);
       console.log('responseUserInfo Complete', responseUserInfo);
-      setKakaoNameState(responseUserInfo.data.properties.nickname);
+      setKakaoInfoState({
+        name: responseUserInfo.data.properties.nickname,
+        image: responseUserInfo.data.properties.profile_image,
+        email: responseUserInfo.data.kakao_account.email,
+      });
     } catch (error) {
       console.log('카카오 정보 가져오기 에러', error);
     }

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
 import { Headers } from '../constants/Header';
+import { KakaoInfo } from '../interface/Kakao';
 export type HeaderSelectedType =
   | 'none'
   | 'list'
@@ -10,9 +11,14 @@ export const headerSelectedState = atom<HeaderSelectedType>({
   key: 'headerSelectedState',
   default: Headers.myProfile,
 });
-export const kakaoNameState = atom({
-  key: 'kakaoNameState',
-  default: 'noname',
+export const kakaoInfoState = atom<KakaoInfo>({
+  key: 'kakaoInfoState',
+  default: {
+    name: 'name',
+    image:
+      'https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi2.ruliweb.com%2Fimg%2F22%2F06%2F06%2F1813491dcbf563e92.jpg&type=ofullfill340_600_png',
+    email: 'email',
+  },
 });
 export const kakaoAccessTokenState = atom({
   key: 'kakaoAccessTokenState',

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -4,11 +4,11 @@ export type HeaderSelectedType =
   | 'none'
   | 'list'
   | 'myTeam'
-  | 'login'
-  | 'myPage'; //추가 가능
+  | 'myProfile'
+  | 'login'; //추가 가능
 export const headerSelectedState = atom<HeaderSelectedType>({
   key: 'headerSelectedState',
-  default: Headers.none,
+  default: Headers.myProfile,
 });
 export const kakaoNameState = atom({
   key: 'kakaoNameState',
@@ -22,4 +22,3 @@ export const loginState = atom<boolean>({
   key: 'loginState',
   default: false,
 });
-

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,6 +1,12 @@
 import { atom } from 'recoil';
 import { Headers } from '../constants/Header';
-import { KakaoInfo } from '../interface/Kakao';
+import { recoilPersist } from 'recoil-persist';
+import { LoginInfo } from '../interface/Login';
+const { persistAtom } = recoilPersist({
+  key: 'recoilPersistTest',
+  storage: sessionStorage,
+});
+
 export type HeaderSelectedType =
   | 'none'
   | 'list'
@@ -11,19 +17,24 @@ export const headerSelectedState = atom<HeaderSelectedType>({
   key: 'headerSelectedState',
   default: Headers.myProfile,
 });
-export const kakaoInfoState = atom<KakaoInfo>({
-  key: 'kakaoInfoState',
-  default: {
-    name: 'name',
-    image:
-      'https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi2.ruliweb.com%2Fimg%2F22%2F06%2F06%2F1813491dcbf563e92.jpg&type=ofullfill340_600_png',
-  },
-});
+// export const kakaoInfoState = atom<KakaoInfo>({
+//   key: 'kakaoInfoState',
+//   default: {
+//     name: 'name',
+//     image:
+//       'https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi2.ruliweb.com%2Fimg%2F22%2F06%2F06%2F1813491dcbf563e92.jpg&type=ofullfill340_600_png',
+//   },
+//   effects_UNSTABLE: [persistAtom],
+// });
 export const kakaoAccessTokenState = atom({
   key: 'kakaoAccessTokenState',
   default: '',
+  effects_UNSTABLE: [persistAtom],
 });
-export const loginState = atom<boolean>({
+export const loginInfoState = atom<LoginInfo>({
   key: 'loginState',
-  default: false,
+  default: {
+    isLogin: false,
+  },
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -17,7 +17,6 @@ export const kakaoInfoState = atom<KakaoInfo>({
     name: 'name',
     image:
       'https://search.pstatic.net/sunny/?src=https%3A%2F%2Fi2.ruliweb.com%2Fimg%2F22%2F06%2F06%2F1813491dcbf563e92.jpg&type=ofullfill340_600_png',
-    email: 'email',
   },
 });
 export const kakaoAccessTokenState = atom({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2524,6 +2524,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+recoil-persist@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-5.1.0.tgz#c4232fe04f2e4b6afcc815baff56f2521f6dcde1"
+  integrity sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==
+
 recoil@^0.7.7:
   version "0.7.7"
   resolved "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz"


### PR DESCRIPTION
### 관련 이슈
close #27 

### PR Checklist for Reviewer

- [ ] 헤더 변경 내용 적용
- [ ] 커스텀 훅을 통한 로그인 확인 로직
- [ ]

### 테스트 결과
![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/77064618/142de6c6-7643-4fb8-898d-1a7d93237c99)
컴포넌트 내에서 토큰을 이용하여 로그인 상태를 검증하고 싶을때, 아래의 사진처럼 커스텀 훅의` handleLogin`함수를 사용해주세요
![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/77064618/ae729672-3970-4718-a27e-3d3f57b92751)



