### PR TITLE
[feat] 페이지 이동 시 스크롤 맨 위로 이동

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -15,11 +15,12 @@ import PaymentComplete from './pages/payment/PaymentComplete';
 import PaymentCharge from './pages/payment/PaymentCharge';
 import Request from './pages/request/Request';
 import Main from './pages/main/Main';
+import ScrollToTop from './components/common/ScrollToTop';
 
 function Router() {
   return (
     <BrowserRouter>
-      <ScrollTop />
+      <ScrollToTop />
       <Header />
       <Routes>
         <Route path="/" element={<Main />} />

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -19,6 +19,7 @@ import Main from './pages/main/Main';
 function Router() {
   return (
     <BrowserRouter>
+      <ScrollTop />
       <Header />
       <Routes>
         <Route path="/" element={<Main />} />

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
### 관련 이슈
- close #38 

### PR Checklist for Reviewer
- [x] ScrollToTop 컴포넌트 생성

### 유의사항
페이지 이동 시 스크롤의 위치가 전 페이지의 위치 그대로 있는 문제 해결  
Router 안에 선언해주어야 pathname 을 인식할 수 있기 때문에 Router.tsx에 넣어놨습니다!

+ 참고 자료
https://velog.io/@tlatjdgh3778/React-%ED%8E%98%EC%9D%B4%EC%A7%80-%EC%9D%B4%EB%8F%99-%EC%8B%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EB%A7%A8-%EC%9C%84%EB%A1%9C-%EC%98%A4%EA%B2%8C-%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95

### 테스트 결과

https://github.com/Kusitms-28th-Meetup-D/frontend/assets/97819580/9d13d8f2-c845-4e8f-b0bc-cbc46011383f

