### PR TITLE
[feat] 공모전 상단의 모집 리스트 API 연동

### DIFF
--- a/src/apis/competition/getRecruitingTeam.tsx
+++ b/src/apis/competition/getRecruitingTeam.tsx
@@ -1,0 +1,7 @@
+import { ResponseRecruitingTeam } from '../../interface/MyTeam';
+import Axios from '../axios';
+
+export async function getRecruitingTeam(): Promise<ResponseRecruitingTeam> {
+  const { data } = await Axios.get(`/api/teams/recruiting`);
+  return data;
+}

--- a/src/components/competitionList/CompetitionRecruiting.tsx
+++ b/src/components/competitionList/CompetitionRecruiting.tsx
@@ -1,15 +1,23 @@
 import { styled } from 'styled-components';
-import { recruitingList } from '../../constants/competitionList';
-import RecruitingBox from './RecruitingBox';
+// import { recruitingList } from '../../constants/competitionList';
+// import RecruitingBox from './RecruitingBox';
 import Pagination from '../common/Pagination';
+import { useRecruitingTeam } from '../../hooks/competition/useRecruitingTeam';
+import RecruitingBox from './RecruitingBox';
 
 const CompetitionRecruiting = () => {
+  const { recruitingTeam } = useRecruitingTeam();
+  console.log(recruitingTeam?.data.recruitingTeams);
+
   return (
     <RecruitingLayout>
       <RecruitingTitle>지금 모집 중인 팀을 만나보세요.</RecruitingTitle>
       <RecruitingBoxLayout>
-        {recruitingList.map((recruiting) => (
-          <RecruitingBox key={recruiting.id} {...recruiting} />
+        {recruitingTeam?.data.recruitingTeams.map((recruitingTeam) => (
+          <RecruitingBox
+            key={recruitingTeam.contestId}
+            recruitingTeam={recruitingTeam}
+          />
         ))}
       </RecruitingBoxLayout>
       <Pagination totalPage={3} currentPage={1} setCurrentPage={() => {}} />
@@ -35,4 +43,5 @@ const RecruitingBoxLayout = styled.div`
   display: flex;
   gap: 2.5rem;
   padding: 0 10rem;
+  width: 100%;
 `;

--- a/src/components/competitionList/RecruitingBox.tsx
+++ b/src/components/competitionList/RecruitingBox.tsx
@@ -1,25 +1,20 @@
 import { styled } from 'styled-components';
+import { RecruitingTeamData } from '../../interface/MyTeam';
 
-interface RecruitingProps {
-  title: string;
-  name: string;
-  description: string;
-  profile: string;
+interface RecruitingBoxProps {
+  recruitingTeam: RecruitingTeamData;
 }
 
-const RecruitingBox = ({
-  title,
-  name,
-  description,
-  profile,
-}: RecruitingProps) => {
+const RecruitingBox = ({ recruitingTeam }: RecruitingBoxProps) => {
   return (
     <RecruitingLayout>
-      <RecruitingTitle>{title}</RecruitingTitle>
+      <RecruitingTitle>{recruitingTeam.contesttitle}</RecruitingTitle>
       <RecruitingHr />
-      <RecruitingProfile src={profile} />
-      <RecruitingName>{name}</RecruitingName>
-      <RecruitingDescription>"{description}"</RecruitingDescription>
+      <RecruitingProfile src={recruitingTeam.teamLeaderImage} />
+      <RecruitingName>{recruitingTeam.teamLeaderName}</RecruitingName>
+      <RecruitingDescription>
+        "{recruitingTeam.teamLeaderMessage}"
+      </RecruitingDescription>
     </RecruitingLayout>
   );
 };
@@ -36,6 +31,7 @@ const RecruitingLayout = styled.div`
   align-items: center;
   border: 1px solid ${({ theme }) => theme.colors.gray20};
   cursor: pointer;
+  width: 20%;
 `;
 
 const RecruitingHr = styled.hr`

--- a/src/constants/Profile.ts
+++ b/src/constants/Profile.ts
@@ -1,40 +1,5 @@
 import { ICategory } from '../interface/Profile';
 
-// export const ProfileSubInfoData: IProfileSubInfoData = {
-//   activitiesData: {
-//     title: '대외활동 및 인턴',
-//     contents: [
-//       '한국대학생IT경영학회 (23.08~): 기획 파트, 팀원 모집 플랫폼 "Wanteam." 기획',
-//       '캐캐오기업 (22.01~22.12): 제품 기획 부서, 초콜릿 신제품 맛보기 테스트',
-//       '코코넛기업 (21.06~21.09): 영업 부서, 코코넛 사세요 맛 좋은 코코넛 사세요',
-//     ],
-//   },
-//   awardsData: {
-//     title: '수상 경력',
-//     contents: [
-//       '초콜릿 맛있게 먹기 공모전 최우수상',
-//       '샘송 광고 기획 아이디어 공모전 장려상',
-//       '멍 때리기 대회 대상',
-//     ],
-//   },
-//   toolsData: {
-//     title: '사용 가능 툴',
-//     contents: [
-//       '노션: 휘황찬란하게 활용하지는 못하지만 적당히 쓸 줄은 알아요!',
-//       '지라: 인턴할 때 써봐서 어느 정도 활용 가능합니다.',
-//       '피그마: 간단한 와이어프레임 정도는 그릴 수 있어요! ',
-//     ],
-//   },
-//   licensesData: {
-//     title: '대외활동 및 인턴',
-//     contents: [
-//       '늦게 자기 자격증 1급',
-//       '해리 포터 덕후 자격증 마스터',
-//       '(G)-IDLE 팬클럽 ‘네버랜드’ 4기',
-//     ],
-//   },
-// };
-
 export const TEAM_CURTURE_CATEGORY: ICategory = {
   title: '팀 문화',
   category: [

--- a/src/constants/competitionList.ts
+++ b/src/constants/competitionList.ts
@@ -1,41 +1,3 @@
-export const recruitingList = [
-  {
-    id: 1,
-    title: '세종특별자치시 2023 일자리 아이디어(정책) 공모전',
-    name: '박형준',
-    description: '봄감자가 맛있답니다',
-    profile: '/assets/images/review/profile.svg',
-  },
-  {
-    id: 2,
-    title: '외국인 인식 개선을 위한 콘텐츠(영상, 웹툰) 제작 공모전',
-    name: '민혜린',
-    description: '봄감자가 맛있답니다',
-    profile: '/assets/images/review/profile.svg',
-  },
-  {
-    id: 3,
-    title: '[인천국제공항공사] 우리동네 여행코스 대국민 공모전',
-    name: '채영대',
-    description: '봄감자가 맛있답니다',
-    profile: '/assets/images/review/profile.svg',
-  },
-  {
-    id: 4,
-    title: '2024 KT&G 국제 대학생 창업교류전(ASVF) 한국 대표 모집',
-    name: '이재영',
-    description: '디자인',
-    profile: '/assets/images/review/profile.svg',
-  },
-  {
-    id: 5,
-    title: '세종특별자치시 2023 일자리 아이디어(정책) 공모전',
-    name: '박진우',
-    description: '프론트엔드',
-    profile: '/assets/images/review/profile.svg',
-  },
-];
-
 export const searchButtonList = [
   '전체',
   '기획/아이디어',
@@ -48,47 +10,4 @@ export const searchButtonList = [
   'IT/소프트웨어/게임',
   '창업/스타트업',
   '기타',
-];
-
-export const competitionList = [
-  {
-    contestId: 1,
-    title: '제 1회 삼성전자 주니어 소프트웨어 창작대회',
-    images: '/assets/images/competition/competition.svg',
-    teamNum: 8,
-    remainDay: 11,
-    company: '한국경제신문',
-  },
-  {
-    contestId: 2,
-    title: '2024 KT&G 국제 대학생 창업교류전(ASVF) 한국 대표 모집',
-    images: '/assets/images/competition/competition.svg',
-    teamNum: 8,
-    remainDay: 11,
-    company: '한국경제신문',
-  },
-  {
-    contestId: 3,
-    title: '제 1회 삼성전자 주니어 소프트웨어 창작대회',
-    images: '/assets/images/competition/competition.svg',
-    teamNum: 8,
-    remainDay: 11,
-    company: '한국경제신문',
-  },
-  {
-    contestId: 4,
-    title: '제 1회 삼성전자 주니어 소프트웨어 창작대회',
-    images: '/assets/images/competition/competition.svg',
-    teamNum: 8,
-    remainDay: 11,
-    company: '한국경제신문',
-  },
-  {
-    contestId: 5,
-    title: '제 1회 삼성전자 주니어 소프트웨어 창작대회',
-    images: '/assets/images/competition/competition.svg',
-    teamNum: 8,
-    remainDay: 11,
-    company: '한국경제신문',
-  },
 ];

--- a/src/hooks/competition/useRecruitingTeam.tsx
+++ b/src/hooks/competition/useRecruitingTeam.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from 'react-query';
+import { ResponseRecruitingTeam } from '../../interface/MyTeam';
+import { recruitingTeamKeys } from '../../keys/competitionKeys';
+import { getRecruitingTeam } from '../../apis/competition/getRecruitingTeam';
+
+interface UseRecruitingTeam {
+  recruitingTeam?: ResponseRecruitingTeam;
+}
+
+export function useRecruitingTeam(): UseRecruitingTeam {
+  const { data: recruitingTeam } = useQuery(recruitingTeamKeys.all, () =>
+    getRecruitingTeam(),
+  );
+  return { recruitingTeam };
+}

--- a/src/interface/MyTeam.ts
+++ b/src/interface/MyTeam.ts
@@ -88,3 +88,30 @@ export interface ResponseEndTeam {
   message: string;
   data: EndTeamData[];
 }
+
+export interface PageResponseDTO {
+  startPage: number;
+  endPage: number;
+  currentPage: number;
+  totalCount: number;
+}
+
+export interface RecruitingTeamData {
+  contestId: string;
+  contesttitle: string;
+  teamLeaderId: number;
+  teamLeaderName: string;
+  teamLeaderImage: string;
+  teamLeaderMessage: string;
+}
+
+export interface RecruitingTeam {
+  pageResponseDTO: PageResponseDTO;
+  recruitingTeams: RecruitingTeamData[];
+}
+
+export interface ResponseRecruitingTeam {
+  status: number;
+  message: string;
+  data: RecruitingTeam;
+}

--- a/src/keys/competitionKeys.tsx
+++ b/src/keys/competitionKeys.tsx
@@ -1,3 +1,7 @@
 export const competitionKeys = {
   all: ['competition'] as const,
 };
+
+export const recruitingTeamKeys = {
+  all: ['recruitingTeam'] as const,
+};


### PR DESCRIPTION
### 관련 이슈
- #84

### PR Checklist for Reviewer
- [ ] 공모전 상단의 모집 리스트 API 연동

### 테스트 결과
![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/97819580/df54a612-b13f-44f9-bb66-7e6da71166e1)
