### PR TITLE
[fix] 모바일 버전 키워드 3개 눌리는 오류

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -31,6 +31,7 @@ import ExternalMobileMain from './components/review/externalMobile/ExternalMobil
 import ExternalMobileOneLine from './components/review/externalMobile/ExternalMobileOneLine';
 import ExternalMobileComplete from './components/review/externalMobile/ExternalMobileComplete';
 import Layout from './components/layout/Layout';
+import ExternalReview from './pages/review/ExternalReview';
 
 function Router() {
   return (
@@ -59,7 +60,7 @@ function Router() {
             <Route path="oneLine" element={<ExternalMobileOneLine />} />
             <Route path="complete" element={<ExternalMobileComplete />} />
           </Route>
-          {/* <Route path="/review/external/:userId" element={<ExternalReview />} /> */}
+          <Route path="/review/external/:userId" element={<ExternalReview />} />
 
           <Route path="/profile/:userId" element={<Profile />} />
           <Route path="/profile/:userId/create" element={<ProfileCreate />} />

--- a/src/components/main/PopularTeamBox.tsx
+++ b/src/components/main/PopularTeamBox.tsx
@@ -18,7 +18,7 @@ const PopularTeamBox = ({
       <h1>{title}</h1>
       <hr />
       <img src={'/assets/images/review/profile.svg'} />
-      <h2>{name}님의 팀</h2>
+      <h2>{name} 님의 팀</h2>
       <p>"{content}"</p>
     </PopularTeamBoxContainer>
   );

--- a/src/components/myteam/management/NoMemberJoinModal.tsx
+++ b/src/components/myteam/management/NoMemberJoinModal.tsx
@@ -45,7 +45,7 @@ const NoMemberJoinModal: React.FC<NoMemberJoinModalProps> = ({
       onCloseClickFunc={handleCloseButtonClick}
     >
       <ModalInner>
-        <Title>{profileProps.teamMemberName}님의 합류를 거절하시겠어요?</Title>
+        <Title>{profileProps.teamMemberName} 님의 합류를 거절하시겠어요?</Title>
         <Content>합류를 거절한 이후에는 취소가 불가능해요.</Content>
         <ProfileBoxMember
           hasBorder={true}

--- a/src/components/myteam/management/YesMemberJoinModal.tsx
+++ b/src/components/myteam/management/YesMemberJoinModal.tsx
@@ -46,7 +46,7 @@ const YesMemberJoinModal: React.FC<YesMemberJoinModalProps> = ({
     >
       <ModalInner>
         <Title>
-          {profileProps.teamMemberName}님과 팀원으로 함께하시겠어요?
+          {profileProps.teamMemberName} 님과 팀원으로 함께하시겠어요?
         </Title>
         <Content>팀원으로 합류한 이후에는 취소가 불가능해요.</Content>
         <ProfileBoxMember

--- a/src/components/review/ExternalReviewHeader.tsx
+++ b/src/components/review/ExternalReviewHeader.tsx
@@ -16,11 +16,11 @@ const ExternalReviewHeader = ({ profileData }: ExternalReviewHeaderProps) => {
             <HeaderLeft>
               <HeaderTitle>
                 <Title>Wanteam의 회원님들에게</Title>
-                <h1>{profileData.username}님을 추천해주세요!</h1>
+                <h1>{profileData.username} 님을 추천해주세요!</h1>
               </HeaderTitle>
               <HeaderSubTitle>
                 <p>
-                  남겨주신 리뷰는 {profileData.username}님의 프로필에
+                  남겨주신 리뷰는 {profileData.username} 님의 프로필에
                   반영됩니다.
                 </p>
                 <p>

--- a/src/components/review/ExternalReviewOneLine.tsx
+++ b/src/components/review/ExternalReviewOneLine.tsx
@@ -14,7 +14,7 @@ const ExternalReviewOneLine = ({ userName }: ExternalReviewOneLineProps) => {
 
   return (
     <ExternalReviewContainer>
-      <h1>{userName}님을 한 줄로 추천한다면?</h1>
+      <h1>{userName} 님을 한 줄로 추천한다면?</h1>
       <div>
         <textarea
           placeholder={'140자 이하로 리뷰를 작성해주세요.'}

--- a/src/components/review/externalMobile/ExternalKeyword.tsx
+++ b/src/components/review/externalMobile/ExternalKeyword.tsx
@@ -1,0 +1,34 @@
+import { css, styled } from 'styled-components';
+
+interface keywordProps {
+  keyword: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+const ExternalKeyword = ({ keyword, selected, onClick }: keywordProps) => {
+  return (
+    <KeywordBox $selected={selected} onClick={onClick}>
+      {keyword}
+    </KeywordBox>
+  );
+};
+
+export default ExternalKeyword;
+
+const KeywordBox = styled.div<{ $selected: boolean }>`
+  background: ${({ theme }) => theme.colors.primary10};
+  color: ${({ theme }) => theme.colors.gray70};
+  ${({ theme }) => theme.fonts.bodyM};
+  border: 1px solid ${({ theme }) => theme.colors.gray20};
+  border-radius: 12px;
+  padding: 6px 14px;
+  cursor: pointer;
+
+  ${(props) =>
+    props.$selected &&
+    css`
+      background: ${({ theme }) => theme.colors.primary60};
+      color: ${({ theme }) => theme.colors.white};
+    `};
+`;

--- a/src/components/review/externalMobile/ExternalMobileComplete.tsx
+++ b/src/components/review/externalMobile/ExternalMobileComplete.tsx
@@ -44,7 +44,7 @@ const ExternalMobileCompleteContainer = styled.div`
     margin-bottom: 1.5rem;
   }
   p {
-    ${({ theme }) => theme.fonts.bodyXXS};
+    ${({ theme }) => theme.fonts.bodyXS};
     color: ${({ theme }) => theme.colors.gray70};
   }
   img {

--- a/src/components/review/externalMobile/ExternalMobileKeyword.tsx
+++ b/src/components/review/externalMobile/ExternalMobileKeyword.tsx
@@ -102,7 +102,7 @@ const ExternalMobileKeywordContainer = styled.div`
     margin-bottom: 0.5rem;
   }
   p {
-    ${({ theme }) => theme.fonts.bodyXXS};
+    ${({ theme }) => theme.fonts.bodyXS};
     color: ${({ theme }) => theme.colors.gray70};
   }
 `;

--- a/src/components/review/externalMobile/ExternalMobileKeyword.tsx
+++ b/src/components/review/externalMobile/ExternalMobileKeyword.tsx
@@ -1,10 +1,10 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import useProfile from '../../../hooks/profile/useProfile';
 import { styled } from 'styled-components';
-import Keyword from '../Keyword';
 import { useContext, useEffect, useState } from 'react';
 import { keywordListWithIds } from '../../../constants/review';
 import { ReviewContext } from '../../../pages/review/ExternalMobileReview';
+import ExternalKeyword from './ExternalKeyword';
 
 const ExternalMobileKeyword = () => {
   const { userId } = useParams();
@@ -48,7 +48,7 @@ const ExternalMobileKeyword = () => {
         <KeywordBox>
           {keywordListWithIds.map(
             (keyword: { id: number; keyword: string }) => (
-              <Keyword
+              <ExternalKeyword
                 key={keyword.id}
                 keyword={keyword.keyword}
                 selected={selectedKeywords.includes(keyword.id)}

--- a/src/components/review/externalMobile/ExternalMobileMain.tsx
+++ b/src/components/review/externalMobile/ExternalMobileMain.tsx
@@ -52,7 +52,7 @@ const ExternalMobileMainContainer = styled.div`
     margin-bottom: 1.5rem;
   }
   p {
-    ${({ theme }) => theme.fonts.bodyXXS};
+    ${({ theme }) => theme.fonts.bodyXS};
     color: ${({ theme }) => theme.colors.gray70};
   }
   img {
@@ -63,7 +63,7 @@ const ExternalMobileMainContainer = styled.div`
 `;
 
 const ButtonStyle = styled(Button)`
-  padding: 1.5rem 3rem;
+  padding: 1.2rem 3rem;
 
-  ${({ theme }) => theme.fonts.subtitleL};
+  ${({ theme }) => theme.fonts.subtitleM};
 `;

--- a/src/components/review/externalMobile/ExternalMobileMain.tsx
+++ b/src/components/review/externalMobile/ExternalMobileMain.tsx
@@ -12,9 +12,9 @@ const ExternalMobileMain = () => {
   return (
     <ExternalMobileMainContainer>
       <h1>Wanteam의 회원님들에게</h1>
-      <h2>{username}님을 추천해주세요!</h2>
+      <h2>{username} 님을 추천해주세요!</h2>
 
-      <p>남겨주신 리뷰는 {username}님의 프로필에 반영됩니다.</p>
+      <p>남겨주신 리뷰는 {username} 님의 프로필에 반영됩니다.</p>
       <p>{username} 님이 멋진 팀원을 구할 수 있도록 도와주세요!</p>
 
       <img

--- a/src/components/review/externalMobile/ExternalMobileOneLine.tsx
+++ b/src/components/review/externalMobile/ExternalMobileOneLine.tsx
@@ -93,7 +93,7 @@ const ExternalMobileOneLineContainer = styled.div`
     margin-bottom: 0.5rem;
   }
   > p {
-    ${({ theme }) => theme.fonts.bodyXXS};
+    ${({ theme }) => theme.fonts.bodyXS};
     color: ${({ theme }) => theme.colors.gray70};
     margin-bottom: 5rem;
   }

--- a/src/components/review/externalMobile/ExternalMobileOneLine.tsx
+++ b/src/components/review/externalMobile/ExternalMobileOneLine.tsx
@@ -42,6 +42,7 @@ const ExternalMobileOneLine = () => {
               setText(e.target.value);
             }}
             value={text}
+            maxLength={140}
           ></Textarea>
           <p>{text.length}/140자</p>
         </TextareaBox>

--- a/src/components/review/externalMobile/ExternalMobileTendency1.tsx
+++ b/src/components/review/externalMobile/ExternalMobileTendency1.tsx
@@ -74,7 +74,7 @@ const ExternalMobileTendency1Container = styled.div`
     margin-bottom: 0.5rem;
   }
   p {
-    ${({ theme }) => theme.fonts.bodyXXS};
+    ${({ theme }) => theme.fonts.bodyXS};
     color: ${({ theme }) => theme.colors.gray70};
   }
 `;

--- a/src/components/review/externalMobile/ExternalMobileTendency2.tsx
+++ b/src/components/review/externalMobile/ExternalMobileTendency2.tsx
@@ -74,7 +74,7 @@ const ExternalMobileTendency2Container = styled.div`
     margin-bottom: 0.5rem;
   }
   p {
-    ${({ theme }) => theme.fonts.bodyXXS};
+    ${({ theme }) => theme.fonts.bodyXS};
     color: ${({ theme }) => theme.colors.gray70};
   }
 `;

--- a/src/constants/review.ts
+++ b/src/constants/review.ts
@@ -3,12 +3,12 @@ export const keywordList = [
   '불타는 열정왕',
   '전공스킬 넘사벽',
   '소통의 귀재',
-  '논리의 왕',
+  '디테일 천재',
   '분위기 메이커',
   '꽉찬 리더십',
-  '경험가득 고인물',
-  '올라운더',
-  '빛의 작업속도',
+  '아이디어 뱅크',
+  '팀워크 최고',
+  '성실의 아이콘',
 ];
 
 export const keywordListWithIds = keywordList.map((keyword, index) => ({

--- a/src/pages/contestTeam/ContestTeam.tsx
+++ b/src/pages/contestTeam/ContestTeam.tsx
@@ -65,7 +65,7 @@ const ContestTeam = () => {
         {'공모전으로 돌아가기'}
       </TeamUndo>
       <TeamTitle>
-        {contestTeamDetailData?.data.data.leaderInfo.teamMemberName}님의 팀
+        {contestTeamDetailData?.data.data.leaderInfo.teamMemberName} 님의 팀
       </TeamTitle>
       <TeamLeaderContainer>
         <LeaderBox>


### PR DESCRIPTION
### 관련 이슈
- close #109 

### PR Checklist for Reviewer
- [ ] 모바일 버전 키워드 3개 눌리는 오류
- [ ] 모바일 외부 추천사 글씨 크기 수정
- [ ] 모바일 외부 추천사 keyword 변경
- [ ] maxLength 140자 추가

### 테스트 결과
Keyword 컴포넌트에 &:hover 속성이 있어서
2개만 선택된 거지만, 3개로 선택된 것처럼 보이는 오류가 있었습니다.
모바일 버전의 Keyword 컴포넌트를 새로 만들어 &:hover 속성을 제외하였습니다.

![image](https://github.com/Kusitms-28th-Meetup-D/frontend/assets/97819580/42deef2b-a462-4310-a1c8-504865652ff3)
